### PR TITLE
Implement codecs

### DIFF
--- a/argo.cabal
+++ b/argo.cabal
@@ -69,6 +69,7 @@ library
         Argo
         Argo.Class.FromValue
         Argo.Class.ToValue
+        Argo.Codec
         Argo.Decode
         Argo.Decoder
         Argo.Encode

--- a/source/library/Argo/Codec.hs
+++ b/source/library/Argo/Codec.hs
@@ -1,0 +1,284 @@
+module Argo.Codec where
+
+import Control.Applicative ((<|>))
+
+import qualified Argo.Json.Array as Array
+import qualified Argo.Json.Boolean as Boolean
+import qualified Argo.Json.Member as Member
+import qualified Argo.Json.Name as Name
+import qualified Argo.Json.Null as Null
+import qualified Argo.Json.Number as Number
+import qualified Argo.Json.Object as Object
+import qualified Argo.Json.String as String
+import qualified Argo.Json.Value as Value
+import qualified Argo.Result as Result
+import qualified Control.Applicative as Applicative
+import qualified Control.Monad as Monad
+import qualified Control.Monad.Trans.Class as Trans
+import qualified Control.Monad.Trans.Except as Except
+import qualified Control.Monad.Trans.Reader as Reader
+import qualified Control.Monad.Trans.State as State
+import qualified Control.Monad.Trans.Writer as Writer
+import qualified Data.Text as Text
+
+decodeWith :: ValueCodec a -> Value.Value -> Result.Result a
+decodeWith c = either fail pure . Except.runExcept . Reader.runReaderT (decode c)
+
+encodeWith :: ValueCodec a -> a -> Value.Value
+encodeWith c x = State.execState (encode c x) . Value.Null $ Null.fromUnit ()
+
+project :: (i -> f) -> CodecOf r w f o -> CodecOf r w i o
+project f c = c { encode = encode c . f }
+
+data CodecOf r w i o = Codec
+    { decode :: r o
+    , encode :: i -> w o
+    }
+
+instance (Functor r, Functor w) => Functor (CodecOf r w i) where
+    fmap f c = Codec
+        { decode = fmap f $ decode c
+        , encode = fmap f . encode c
+        }
+
+instance (Applicative r, Applicative w) => Applicative (CodecOf r w i) where
+    pure x = Codec
+        { decode = pure x
+        , encode = const $ pure x
+        }
+    cf <*> cx = Codec
+        { decode = decode cf <*> decode cx
+        , encode = \ i -> encode cf i <*> encode cx i
+        }
+
+instance (Applicative.Alternative r, Applicative.Alternative w) => Applicative.Alternative (CodecOf r w i) where
+    empty = Codec
+        { decode = Applicative.empty
+        , encode = const Applicative.empty
+        }
+    cx <|> cy = Codec
+        { decode = decode cx <|> decode cy
+        , encode = \ i -> encode cx i <|> encode cy i
+        }
+
+type Codec r w a = CodecOf r w a a
+
+dimap :: (Functor r, Functor w) => (a -> b) -> (b -> a) -> Codec r w a -> Codec r w b
+dimap f g c = Codec
+    { decode = fmap f $ decode c
+    , encode = fmap f . encode c . g
+    }
+
+type ValueCodec a = Codec
+    (Reader.ReaderT Value.Value (Except.Except String))
+    (State.State Value.Value)
+    a
+
+valueCodec :: ValueCodec Value.Value
+valueCodec = Codec
+    { decode = Reader.ask
+    , encode = \ x -> do
+        State.put x
+        pure x
+    }
+
+nullCodec :: ValueCodec Null.Null
+nullCodec = Codec
+    { decode = do
+        x <- Reader.ask
+        case x of
+            Value.Null y -> pure y
+            _ -> Trans.lift . Except.throwE $ "expected Null but got " <> show x
+    , encode = \ x -> do
+        State.put $ Value.Null x
+        pure x
+    }
+
+booleanCodec :: ValueCodec Boolean.Boolean
+booleanCodec = Codec
+    { decode = do
+        x <- Reader.ask
+        case x of
+            Value.Boolean y -> pure y
+            _ -> Trans.lift . Except.throwE $ "expected Boolean but got " <> show x
+    , encode = \ x -> do
+        State.put $ Value.Boolean x
+        pure x
+    }
+
+numberCodec :: ValueCodec Number.Number
+numberCodec = Codec
+    { decode = do
+        x <- Reader.ask
+        case x of
+            Value.Number y -> pure y
+            _ -> Trans.lift . Except.throwE $ "expected Number but got " <> show x
+    , encode = \ x -> do
+        State.put $ Value.Number x
+        pure x
+    }
+
+stringCodec :: ValueCodec String.String
+stringCodec = Codec
+    { decode = do
+        x <- Reader.ask
+        case x of
+            Value.String y -> pure y
+            _ -> Trans.lift . Except.throwE $ "expected String but got " <> show x
+    , encode = \ x -> do
+        State.put $ Value.String x
+        pure x
+    }
+
+arrayCodec :: ValueCodec (Array.ArrayOf Value.Value)
+arrayCodec = Codec
+    { decode = do
+        x <- Reader.ask
+        case x of
+            Value.Array y -> pure y
+            _ -> Trans.lift . Except.throwE $ "expected Array but got " <> show x
+    , encode = \ x -> do
+        State.put $ Value.Array x
+        pure x
+    }
+
+objectCodec :: ValueCodec (Object.ObjectOf Value.Value)
+objectCodec = Codec
+    { decode = do
+        x <- Reader.ask
+        case x of
+            Value.Object y -> pure y
+            _ -> Trans.lift . Except.throwE $ "expected Object but got " <> show x
+    , encode = \ x -> do
+        State.put $ Value.Object x
+        pure x
+    }
+
+boolCodec :: ValueCodec Bool
+boolCodec = dimap Boolean.toBool Boolean.fromBool booleanCodec
+
+textCodec :: ValueCodec Text.Text
+textCodec = dimap String.toText String.fromText stringCodec
+
+eitherCodec :: ValueCodec a -> ValueCodec b -> ValueCodec (Either a b)
+eitherCodec c1 c2 = Codec
+    { decode = fmap Left (decode c1) <|> fmap Right (decode c2)
+    , encode = \ x -> case x of
+        Left y -> fmap Left $ encode c1 y
+        Right y -> fmap Right $ encode c2 y
+    }
+
+maybeCodec :: ValueCodec a -> ValueCodec (Maybe a)
+maybeCodec =
+    dimap
+        (either Just $ const Nothing)
+        (maybe (Right $ Null.fromUnit ()) Left)
+    . flip eitherCodec nullCodec
+
+data Permission
+    = Allow
+    | Forbid
+    deriving (Eq, Show)
+
+type ArrayCodec a = Codec
+    (State.StateT [Value.Value] (Except.Except String))
+    (Writer.Writer [Value.Value])
+    a
+
+fromArrayCodec :: Permission -> ArrayCodec a -> ValueCodec a
+fromArrayCodec p c = Codec
+    { decode = do
+        xs <- decode arrayCodec
+        case Except.runExcept . State.runStateT (decode c) $ Array.toList xs of
+            Left x -> Trans.lift $ Except.throwE x
+            Right (x, ys) -> do
+                case (p, ys) of
+                    (Forbid, _ : _) -> Trans.lift $ Except.throwE "leftover elements"
+                    _ -> pure ()
+                pure x
+    , encode = \ x -> do
+        Monad.void . encode arrayCodec . Array.fromList . Writer.execWriter $ encode c x
+        pure x
+    }
+
+element :: ValueCodec a -> ArrayCodec a
+element c = Codec
+    { decode = do
+        l <- State.get
+        case l of
+            [] -> Trans.lift $ Except.throwE "unexpected empty list"
+            h : t ->  case decodeWith c h of
+                Result.Failure y -> Trans.lift $ Except.throwE y
+                Result.Success y -> do
+                    State.put t
+                    pure y
+    , encode = \ x -> do
+        Writer.tell [encodeWith c x]
+        pure x
+    }
+
+tupleCodec :: ValueCodec a -> ValueCodec b -> ValueCodec (a, b)
+tupleCodec cx cy = fromArrayCodec Forbid $ (,)
+    <$> project fst (element cx)
+    <*> project snd (element cy)
+
+type ObjectCodec a = Codec
+    (State.StateT [Member.MemberOf Value.Value] (Except.Except String))
+    (Writer.Writer [Member.MemberOf Value.Value])
+    a
+
+fromObjectCodec :: Permission -> ObjectCodec a -> ValueCodec a
+fromObjectCodec p c = Codec
+    { decode = do
+        xs <- decode objectCodec
+        case Except.runExcept . State.runStateT (decode c) $ Object.toList xs of
+            Left x -> Trans.lift $ Except.throwE x
+            Right (x, ys) -> do
+                case (p, ys) of
+                    (Forbid, _ : _) -> Trans.lift $ Except.throwE "leftover members"
+                    _ -> pure ()
+                pure x
+    , encode = \ x -> do
+        Monad.void . encode objectCodec . Object.fromList . Writer.execWriter $ encode c x
+        pure x
+    }
+
+required :: Name.Name -> ValueCodec a -> ObjectCodec a
+required k c = Codec
+    { decode = do
+        m <- decode (optional k c)
+        case m of
+            Nothing -> Trans.lift . Except.throwE $ "missing required member: " <> show k
+            Just x -> pure x
+    , encode = \ x -> do
+        Monad.void . encode (optional k c) $ Just x
+        pure x
+    }
+
+optional :: Name.Name -> ValueCodec a -> ObjectCodec (Maybe a)
+optional k c = Codec
+    { decode = do
+        xs <- State.get
+        case detect (\ (Member.Member j _) -> j == k) xs of
+            Nothing -> pure Nothing
+            Just (Member.Member _ x, ys) -> case decodeWith c x of
+                Result.Failure y -> Trans.lift $ Except.throwE y
+                Result.Success y -> do
+                    State.put ys
+                    pure $ Just y
+    , encode = \ x -> do
+        case x of
+            Nothing -> pure ()
+            Just y -> Writer.tell [Member.Member k $ encodeWith c y]
+        pure x
+    }
+
+detect :: (a -> Bool) -> [a] -> Maybe (a, [a])
+detect = detectWith id
+
+detectWith :: ([a] -> [a]) -> (a -> Bool) -> [a] -> Maybe (a, [a])
+detectWith f p xs = case xs of
+    [] -> Nothing
+    x : ys -> if p x
+        then Just (x, f ys)
+        else detectWith (f . (x :)) p ys

--- a/source/library/Argo/Codec.hs
+++ b/source/library/Argo/Codec.hs
@@ -163,9 +163,7 @@ textCodec = dimap String.toText String.fromText stringCodec
 eitherCodec :: ValueCodec a -> ValueCodec b -> ValueCodec (Either a b)
 eitherCodec c1 c2 = Codec
     { decode = fmap Left (decode c1) <|> fmap Right (decode c2)
-    , encode = \ x -> case x of
-        Left y -> fmap Left $ encode c1 y
-        Right y -> fmap Right $ encode c2 y
+    , encode = either (fmap Left . encode c1) (fmap Right . encode c2)
     }
 
 maybeCodec :: ValueCodec a -> ValueCodec (Maybe a)

--- a/source/library/Argo/Encode.hs
+++ b/source/library/Argo/Encode.hs
@@ -15,8 +15,9 @@ encode = encodeWith $ Encoder.Spaces 0
 encodeWith :: ToValue.ToValue a => Encoder.Indent -> a -> Builder.Builder
 encodeWith i x =
     let c = Encoder.Config { Encoder.indent = i, Encoder.level = 0 }
-    in Identity.runIdentity
-    . Trans.execWriterT
+    in snd
+    . Identity.runIdentity
+    . Trans.runWriterT
     . flip Trans.runReaderT c
     $ do
         Value.encode $ ToValue.toValue x

--- a/source/library/Argo/Encoder.hs
+++ b/source/library/Argo/Encoder.hs
@@ -37,7 +37,7 @@ list l r s f xs = case xs of
         c <- Trans.ask
         let newLine = if hasIndent c then Builder.word8 Literal.newLine else mempty
         Trans.local increaseLevel $ do
-            i <- Trans.asks makeIndent
+            i <- makeIndent <$> Trans.ask
             Trans.lift . Trans.tell $ newLine <> i
             f x
             Monad.forM_ ys $ \ y -> do

--- a/source/library/Argo/Json/Boolean.hs
+++ b/source/library/Argo/Json/Boolean.hs
@@ -19,17 +19,23 @@ newtype Boolean
     = Boolean Bool
     deriving (Eq, Generics.Generic, TH.Lift, DeepSeq.NFData, Show)
 
+fromBool :: Bool -> Boolean
+fromBool = Boolean
+
+toBool :: Boolean -> Bool
+toBool (Boolean x) = x
+
 encode :: Boolean -> Encoder.Encoder ()
-encode (Boolean x) = Trans.lift
+encode x = Trans.lift
     . Trans.tell
     . Builder.byteString
-    $ if x then Literal.true else Literal.false
+    $ if toBool x then Literal.true else Literal.false
 
 decode :: Decoder.Decoder Boolean
 decode = decodeFalse <|> decodeTrue
 
 decodeFalse :: Decoder.Decoder Boolean
-decodeFalse = Boolean False <$ Decoder.byteString Literal.false <* Decoder.spaces
+decodeFalse = fromBool False <$ Decoder.byteString Literal.false <* Decoder.spaces
 
 decodeTrue :: Decoder.Decoder Boolean
-decodeTrue = Boolean True <$ Decoder.byteString Literal.true <* Decoder.spaces
+decodeTrue = fromBool True <$ Decoder.byteString Literal.true <* Decoder.spaces

--- a/source/library/Argo/Json/Name.hs
+++ b/source/library/Argo/Json/Name.hs
@@ -15,8 +15,14 @@ newtype Name
     = Name String.String
     deriving (Eq, Generics.Generic, TH.Lift, DeepSeq.NFData, Show)
 
+fromString :: String.String -> Name
+fromString = Name
+
+toString :: Name -> String.String
+toString (Name x) = x
+
 encode :: Name -> Encoder.Encoder ()
-encode (Name x) = String.encode x
+encode = String.encode . toString
 
 decode :: Decoder.Decoder Name
-decode = Name <$> String.decode
+decode = fromString <$> String.decode

--- a/source/library/Argo/Json/Null.hs
+++ b/source/library/Argo/Json/Null.hs
@@ -17,8 +17,14 @@ newtype Null
     = Null ()
     deriving (Eq, Generics.Generic, TH.Lift, DeepSeq.NFData, Show)
 
+fromUnit :: () -> Null
+fromUnit = Null
+
+toUnit :: Null -> ()
+toUnit (Null x) = x
+
 encode :: Null -> Encoder.Encoder ()
 encode = const . Trans.lift . Trans.tell $ Builder.byteString Literal.null
 
 decode :: Decoder.Decoder Null
-decode = Null () <$ Decoder.byteString Literal.null <* Decoder.spaces
+decode = fromUnit () <$ Decoder.byteString Literal.null <* Decoder.spaces

--- a/source/library/Argo/Literal.hs
+++ b/source/library/Argo/Literal.hs
@@ -18,9 +18,6 @@ comma = 0x2c
 digitNine :: Word.Word8
 digitNine = 0x39
 
-digitOne :: Word.Word8
-digitOne = 0x31
-
 digitZero :: Word.Word8
 digitZero = 0x30
 

--- a/source/library/Argo/Vendor/Transformers.hs
+++ b/source/library/Argo/Vendor/Transformers.hs
@@ -1,5 +1,6 @@
 module Argo.Vendor.Transformers
     ( ExceptT.ExceptT
+    , MaybeT.MaybeT
     , ReaderT.ReaderT
     , StateT.StateT
     , WriterT.WriterT
@@ -9,6 +10,7 @@ module Argo.Vendor.Transformers
     , ReaderT.local
     , StateT.put
     , ExceptT.runExceptT
+    , MaybeT.runMaybeT
     , ReaderT.runReaderT
     , StateT.runStateT
     , WriterT.runWriterT
@@ -18,6 +20,7 @@ module Argo.Vendor.Transformers
 
 import qualified Control.Monad.Trans.Class as Trans
 import qualified Control.Monad.Trans.Except as ExceptT
+import qualified Control.Monad.Trans.Maybe as MaybeT
 import qualified Control.Monad.Trans.Reader as ReaderT
 import qualified Control.Monad.Trans.State as StateT
 import qualified Control.Monad.Trans.Writer as WriterT

--- a/source/library/Argo/Vendor/Transformers.hs
+++ b/source/library/Argo/Vendor/Transformers.hs
@@ -1,15 +1,23 @@
 module Argo.Vendor.Transformers
-    ( ReaderT.ReaderT
+    ( ExceptT.ExceptT
+    , ReaderT.ReaderT
+    , StateT.StateT
     , WriterT.WriterT
     , ReaderT.ask
-    , ReaderT.asks
-    , WriterT.execWriterT
+    , StateT.get
     , Trans.lift
     , ReaderT.local
+    , StateT.put
+    , ExceptT.runExceptT
     , ReaderT.runReaderT
+    , StateT.runStateT
+    , WriterT.runWriterT
     , WriterT.tell
+    , ExceptT.throwE
     ) where
 
 import qualified Control.Monad.Trans.Class as Trans
+import qualified Control.Monad.Trans.Except as ExceptT
 import qualified Control.Monad.Trans.Reader as ReaderT
+import qualified Control.Monad.Trans.State as StateT
 import qualified Control.Monad.Trans.Writer as WriterT

--- a/source/test-suite/Main.hs
+++ b/source/test-suite/Main.hs
@@ -493,6 +493,12 @@ main = Tasty.defaultMain $ Tasty.testGroup "Argo"
         , Tasty.testCase "decode maybe text" $ do
             Codec.decodeWith (Codec.maybeCodec Codec.textCodec) Argo.Null @?= Argo.Success Nothing
             Codec.decodeWith (Codec.maybeCodec Codec.textCodec) (Argo.String "") @?= Argo.Success (Just "")
+        , Tasty.testCase "encode either text bool" $ do
+            Codec.encodeWith (Codec.eitherCodec Codec.textCodec Codec.boolCodec) (Left "") @?= Argo.Object [Argo.Member (Argo.Name "type") $ Argo.String "Left", Argo.Member (Argo.Name "value") $ Argo.String ""]
+            Codec.encodeWith (Codec.eitherCodec Codec.textCodec Codec.boolCodec) (Right False) @?= Argo.Object [Argo.Member (Argo.Name "type") $ Argo.String "Right", Argo.Member (Argo.Name "value") $ Argo.Boolean False]
+        , Tasty.testCase "decode either text bool" $ do
+            Codec.decodeWith (Codec.eitherCodec Codec.textCodec Codec.boolCodec) (Argo.Object [Argo.Member (Argo.Name "type") $ Argo.String "Left", Argo.Member (Argo.Name "value") $ Argo.String ""]) @?= Argo.Success (Left "")
+            Codec.decodeWith (Codec.eitherCodec Codec.textCodec Codec.boolCodec) (Argo.Object [Argo.Member (Argo.Name "type") $ Argo.String "Right", Argo.Member (Argo.Name "value") $ Argo.Boolean False]) @?= Argo.Success (Right False)
         , Tasty.testCase "encode tuple text bool" $ do
             Codec.encodeWith (Codec.tupleCodec Codec.textCodec Codec.boolCodec) ("", False) @?= Argo.Array [Argo.String "", Argo.Boolean False]
         , Tasty.testCase "decode tuple text bool" $ do

--- a/source/test-suite/Main.hs
+++ b/source/test-suite/Main.hs
@@ -487,12 +487,6 @@ main = Tasty.defaultMain $ Tasty.testGroup "Argo"
             Codec.encodeWith Codec.boolCodec False @?= Argo.Boolean False
         , Tasty.testCase "decode bool" $ do
             Codec.decodeWith Codec.boolCodec (Argo.Boolean False) @?= Argo.Success False
-        , Tasty.testCase "encode either text bool" $ do
-            Codec.encodeWith (Codec.eitherCodec Codec.textCodec Codec.boolCodec) (Left "") @?= Argo.String ""
-            Codec.encodeWith (Codec.eitherCodec Codec.textCodec Codec.boolCodec) (Right False) @?= Argo.Boolean False
-        , Tasty.testCase "decode either text bool" $ do
-            Codec.decodeWith (Codec.eitherCodec Codec.textCodec Codec.boolCodec) (Argo.String "") @?= Argo.Success (Left "")
-            Codec.decodeWith (Codec.eitherCodec Codec.textCodec Codec.boolCodec) (Argo.Boolean False) @?= Argo.Success (Right False)
         , Tasty.testCase "encode maybe text" $ do
             Codec.encodeWith (Codec.maybeCodec Codec.textCodec) Nothing @?= Argo.Null
             Codec.encodeWith (Codec.maybeCodec Codec.textCodec) (Just "") @?= Argo.String ""

--- a/source/test-suite/Main.hs
+++ b/source/test-suite/Main.hs
@@ -9,6 +9,7 @@ import Test.Tasty.HUnit ((@?=))
 import Test.Tasty.QuickCheck ((===))
 
 import qualified Argo
+import qualified Argo.Codec as Codec
 import qualified Data.ByteString as ByteString
 import qualified Data.ByteString.Builder as Builder
 import qualified Data.ByteString.Lazy as LazyByteString
@@ -477,7 +478,49 @@ main = Tasty.defaultMain $ Tasty.testGroup "Argo"
                 Argo.fromValue (Argo.toValue x) === Argo.Success (x :: Map.Map Text.Text Bool)
             ]
         ]
+    , Tasty.testGroup "Codec"
+        [ Tasty.testCase "encode text" $ do
+            Codec.encodeWith Codec.textCodec "" @?= Argo.String ""
+        , Tasty.testCase "decode text" $ do
+            Codec.decodeWith Codec.textCodec (Argo.String "") @?= Argo.Success ""
+        , Tasty.testCase "encode bool" $ do
+            Codec.encodeWith Codec.boolCodec False @?= Argo.Boolean False
+        , Tasty.testCase "decode bool" $ do
+            Codec.decodeWith Codec.boolCodec (Argo.Boolean False) @?= Argo.Success False
+        , Tasty.testCase "encode either text bool" $ do
+            Codec.encodeWith (Codec.eitherCodec Codec.textCodec Codec.boolCodec) (Left "") @?= Argo.String ""
+            Codec.encodeWith (Codec.eitherCodec Codec.textCodec Codec.boolCodec) (Right False) @?= Argo.Boolean False
+        , Tasty.testCase "decode either text bool" $ do
+            Codec.decodeWith (Codec.eitherCodec Codec.textCodec Codec.boolCodec) (Argo.String "") @?= Argo.Success (Left "")
+            Codec.decodeWith (Codec.eitherCodec Codec.textCodec Codec.boolCodec) (Argo.Boolean False) @?= Argo.Success (Right False)
+        , Tasty.testCase "encode maybe text" $ do
+            Codec.encodeWith (Codec.maybeCodec Codec.textCodec) Nothing @?= Argo.Null
+            Codec.encodeWith (Codec.maybeCodec Codec.textCodec) (Just "") @?= Argo.String ""
+        , Tasty.testCase "decode maybe text" $ do
+            Codec.decodeWith (Codec.maybeCodec Codec.textCodec) Argo.Null @?= Argo.Success Nothing
+            Codec.decodeWith (Codec.maybeCodec Codec.textCodec) (Argo.String "") @?= Argo.Success (Just "")
+        , Tasty.testCase "encode tuple text bool" $ do
+            Codec.encodeWith (Codec.tupleCodec Codec.textCodec Codec.boolCodec) ("", False) @?= Argo.Array [Argo.String "", Argo.Boolean False]
+        , Tasty.testCase "decode tuple text bool" $ do
+            Codec.decodeWith (Codec.tupleCodec Codec.textCodec Codec.boolCodec) (Argo.Array [Argo.String "", Argo.Boolean False]) @?= Argo.Success ("", False)
+        , Tasty.testCase "encode record" $ do
+            Codec.encodeWith recordCodec (Record False Nothing) @?= Argo.Object [Argo.Member (Argo.Name "bool") $ Argo.Boolean False]
+            Codec.encodeWith recordCodec (Record False $ Just "") @?= Argo.Object [Argo.Member (Argo.Name "bool") $ Argo.Boolean False, Argo.Member (Argo.Name "text") $ Argo.String ""]
+        , Tasty.testCase "decode record" $ do
+            Codec.decodeWith recordCodec (Argo.Object [Argo.Member (Argo.Name "bool") $ Argo.Boolean False]) @?= Argo.Success (Record False Nothing)
+            Codec.decodeWith recordCodec (Argo.Object [Argo.Member (Argo.Name "bool") $ Argo.Boolean False, Argo.Member (Argo.Name "text") $ Argo.String ""]) @?= Argo.Success (Record False $ Just "")
+        ]
     ]
+
+data Record = Record
+    { recordBool :: Bool
+    , recordText :: Maybe Text.Text
+    } deriving (Eq, Show)
+
+recordCodec :: Codec.ValueCodec Record
+recordCodec = Codec.fromObjectCodec Codec.Allow $ Record
+    <$> Codec.project recordBool (Codec.required (Argo.Name "bool") Codec.boolCodec)
+    <*> Codec.project recordText (Codec.optional (Argo.Name "text") Codec.textCodec)
 
 property
     :: (Show t, Tasty.Testable prop, Tasty.Arbitrary t)


### PR DESCRIPTION
Fixes #16.

This pull request implements codecs, which simultaneously define how to encode and decode something. The functionality is complete, but I haven't yet decided on how to expose this interface. Should it complement `FromValue` and `ToValue`, or should it replace those? Should it use operators like `.=` for defining codecs, or is the `project` function ergonomic? When dealing with objects, is there an elegant way to change from a list to a map for performance reasons? And how does all of this affect performance? 