### PR TITLE
Allow schemas to reference other schemas

### DIFF
--- a/.github/workflows/brittany.yaml
+++ b/.github/workflows/brittany.yaml
@@ -2,7 +2,7 @@ name: Brittany
 on: push
 jobs:
   brittany:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: tfausak/brittany-action@v1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,9 +41,7 @@ jobs:
 
       - run: cabal freeze
 
-      - run: cat cabal.project.freeze
-
-      - run: cp cabal.project.freeze ${{ steps.artifact.outputs.directory }}
+      - run: cat cabal.project.freeze | tee ${{ steps.artifact.outputs.directory }}
 
       - uses: actions/cache@v2
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,7 +41,9 @@ jobs:
 
       - run: cabal freeze
 
-      - run: cat cabal.project.freeze | tee ${{ steps.artifact.outputs.directory }}
+      - run: cat cabal.project.freeze
+
+      - run: cp cabal.project.freeze ${{ steps.artifact.outputs.directory }}
 
       - uses: actions/cache@v2
         with:

--- a/.github/workflows/hlint.yaml
+++ b/.github/workflows/hlint.yaml
@@ -2,7 +2,7 @@ name: HLint
 on: push
 jobs:
   hlint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: tfausak/hlint-action@v1

--- a/argo.cabal
+++ b/argo.cabal
@@ -90,6 +90,7 @@ library
         Argo.Pointer.Pointer
         Argo.Pointer.Token
         Argo.QuasiQuoter
+        Argo.Schema.Identifier
         Argo.Schema.Schema
         Argo.Type.Config
         Argo.Type.Decimal

--- a/argo.cabal
+++ b/argo.cabal
@@ -132,6 +132,7 @@ benchmark argo-benchmark
     import: executable
 
     build-depends:
+        , tasty >= 1.4.2 && < 1.5
         , tasty-bench >= 0.2.5 && < 0.4
     hs-source-dirs: source/benchmark
     main-is: Main.hs

--- a/source/library/Argo/Class/HasCodec.hs
+++ b/source/library/Argo/Class/HasCodec.hs
@@ -45,7 +45,9 @@ instance HasCodec Value.Value where
     codec = Codec.Codec
         { Codec.decode = Trans.ask
         , Codec.encode = Codec.tap $ Trans.lift . Trans.put
-        , Codec.schema = pure (Nothing, Schema.true)
+        , Codec.schema = pure $ Schema.identified
+            (Identifier.fromText $ Text.pack "value")
+            Schema.true
         }
 
 instance HasCodec Null.Null where
@@ -58,7 +60,8 @@ instance HasCodec Null.Null where
                        (Maybe Identifier.Identifier, Schema.Schema)
             schema =
                 pure
-                    . (,) Nothing
+                    . Schema.identified
+                          (Identifier.fromText $ Text.pack "null")
                     . Schema.fromValue
                     . Value.Object
                     $ Object.fromList
@@ -83,7 +86,8 @@ instance HasCodec Boolean.Boolean where
                        (Maybe Identifier.Identifier, Schema.Schema)
             schema =
                 pure
-                    . (,) Nothing
+                    . Schema.identified
+                          (Identifier.fromText $ Text.pack "boolean")
                     . Schema.fromValue
                     . Value.Object
                     $ Object.fromList
@@ -108,7 +112,8 @@ instance HasCodec Number.Number where
                        (Maybe Identifier.Identifier, Schema.Schema)
             schema =
                 pure
-                    . (,) Nothing
+                    . Schema.identified
+                          (Identifier.fromText $ Text.pack "number")
                     . Schema.fromValue
                     . Value.Object
                     $ Object.fromList
@@ -133,7 +138,8 @@ instance HasCodec String.String where
                        (Maybe Identifier.Identifier, Schema.Schema)
             schema =
                 pure
-                    . (,) Nothing
+                    . Schema.identified
+                          (Identifier.fromText $ Text.pack "string")
                     . Schema.fromValue
                     . Value.Object
                     $ Object.fromList
@@ -166,9 +172,14 @@ instance HasCodec a => HasCodec (Array.Array a) where
             . fmap (Codec.encodeWith codec)
             . Array.toList
         , Codec.schema = do
-            (_, schema) <- Codec.schema (codec :: Codec.Value a)
+            (m, schema) <- Codec.schema (codec :: Codec.Value a)
             pure
-                . (,) Nothing
+                . maybe
+                      Schema.unidentified
+                      (Schema.identified
+                      . (Identifier.fromText (Text.pack "array-") <>)
+                      )
+                      m
                 . Schema.fromValue
                 . Value.Object
                 $ Object.fromList
@@ -209,9 +220,14 @@ instance HasCodec a => HasCodec (Object.Object a) where
                   )
             . Object.toList
         , Codec.schema = do
-            (_, schema) <- Codec.schema (codec :: Codec.Value a)
+            (m, schema) <- Codec.schema (codec :: Codec.Value a)
             pure
-                . (,) Nothing
+                . maybe
+                      Schema.unidentified
+                      (Schema.identified
+                      . (Identifier.fromText (Text.pack "object-") <>)
+                      )
+                      m
                 . Schema.fromValue
                 . Value.Object
                 $ Object.fromList
@@ -434,7 +450,8 @@ instance HasCodec Char where
                        (Maybe Identifier.Identifier, Schema.Schema)
             schema =
                 pure
-                    . (,) Nothing
+                    . Schema.identified
+                          (Identifier.fromText $ Text.pack "char")
                     . Schema.fromValue
                     . Value.Object
                     $ Object.fromList
@@ -479,9 +496,15 @@ instance HasCodec a => HasCodec (NonEmpty.NonEmpty a) where
                        Identity.Identity
                        (Maybe Identifier.Identifier, Schema.Schema)
             schema = do
-                (_, itemSchema) <- Codec.schema (codec :: Codec.Value a)
+                (m, itemSchema) <- Codec.schema (codec :: Codec.Value a)
                 pure
-                    . (,) Nothing
+                    . maybe
+                          Schema.unidentified
+                          (Schema.identified
+                          . (Identifier.fromText (Text.pack "non-empty-") <>
+                            )
+                          )
+                          m
                     . Schema.fromValue
                     . Value.Object
                     $ Object.fromList
@@ -519,7 +542,8 @@ instance HasCodec Integer where
                        (Maybe Identifier.Identifier, Schema.Schema)
             schema =
                 pure
-                    . (,) Nothing
+                    . Schema.identified
+                          (Identifier.fromText $ Text.pack "integer")
                     . Schema.fromValue
                     . Value.Object
                     $ Object.fromList
@@ -547,7 +571,7 @@ instance HasCodec Int where
                        (Maybe Identifier.Identifier, Schema.Schema)
             schema =
                 pure
-                    . (,) Nothing
+                    . Schema.identified (Identifier.fromText $ Text.pack "int")
                     . Schema.fromValue
                     . Value.Object
                     $ Object.fromList
@@ -588,7 +612,8 @@ instance HasCodec Int.Int8 where
                        (Maybe Identifier.Identifier, Schema.Schema)
             schema =
                 pure
-                    . (,) Nothing
+                    . Schema.identified
+                          (Identifier.fromText $ Text.pack "int8")
                     . Schema.fromValue
                     . Value.Object
                     $ Object.fromList
@@ -629,7 +654,8 @@ instance HasCodec Int.Int16 where
                        (Maybe Identifier.Identifier, Schema.Schema)
             schema =
                 pure
-                    . (,) Nothing
+                    . Schema.identified
+                          (Identifier.fromText $ Text.pack "int16")
                     . Schema.fromValue
                     . Value.Object
                     $ Object.fromList
@@ -670,7 +696,8 @@ instance HasCodec Int.Int32 where
                        (Maybe Identifier.Identifier, Schema.Schema)
             schema =
                 pure
-                    . (,) Nothing
+                    . Schema.identified
+                          (Identifier.fromText $ Text.pack "int32")
                     . Schema.fromValue
                     . Value.Object
                     $ Object.fromList
@@ -711,7 +738,8 @@ instance HasCodec Int.Int64 where
                        (Maybe Identifier.Identifier, Schema.Schema)
             schema =
                 pure
-                    . (,) Nothing
+                    . Schema.identified
+                          (Identifier.fromText $ Text.pack "int64")
                     . Schema.fromValue
                     . Value.Object
                     $ Object.fromList
@@ -752,7 +780,8 @@ instance HasCodec Natural.Natural where
                        (Maybe Identifier.Identifier, Schema.Schema)
             schema =
                 pure
-                    . (,) Nothing
+                    . Schema.identified
+                          (Identifier.fromText $ Text.pack "natural")
                     . Schema.fromValue
                     . Value.Object
                     $ Object.fromList
@@ -784,7 +813,8 @@ instance HasCodec Word where
                        (Maybe Identifier.Identifier, Schema.Schema)
             schema =
                 pure
-                    . (,) Nothing
+                    . Schema.identified
+                          (Identifier.fromText $ Text.pack "word")
                     . Schema.fromValue
                     . Value.Object
                     $ Object.fromList
@@ -825,7 +855,8 @@ instance HasCodec Word.Word8 where
                        (Maybe Identifier.Identifier, Schema.Schema)
             schema =
                 pure
-                    . (,) Nothing
+                    . Schema.identified
+                          (Identifier.fromText $ Text.pack "word8")
                     . Schema.fromValue
                     . Value.Object
                     $ Object.fromList
@@ -866,7 +897,8 @@ instance HasCodec Word.Word16 where
                        (Maybe Identifier.Identifier, Schema.Schema)
             schema =
                 pure
-                    . (,) Nothing
+                    . Schema.identified
+                          (Identifier.fromText $ Text.pack "word16")
                     . Schema.fromValue
                     . Value.Object
                     $ Object.fromList
@@ -907,7 +939,8 @@ instance HasCodec Word.Word32 where
                        (Maybe Identifier.Identifier, Schema.Schema)
             schema =
                 pure
-                    . (,) Nothing
+                    . Schema.identified
+                          (Identifier.fromText $ Text.pack "word32")
                     . Schema.fromValue
                     . Value.Object
                     $ Object.fromList
@@ -948,7 +981,8 @@ instance HasCodec Word.Word64 where
                        (Maybe Identifier.Identifier, Schema.Schema)
             schema =
                 pure
-                    . (,) Nothing
+                    . Schema.identified
+                          (Identifier.fromText $ Text.pack "word64")
                     . Schema.fromValue
                     . Value.Object
                     $ Object.fromList

--- a/source/library/Argo/Class/HasCodec.hs
+++ b/source/library/Argo/Class/HasCodec.hs
@@ -19,6 +19,7 @@ import qualified Argo.Json.Object as Object
 import qualified Argo.Json.String as String
 import qualified Argo.Json.Value as Value
 import qualified Argo.Pointer.Pointer as Pointer
+import qualified Argo.Schema.Identifier as Identifier
 import qualified Argo.Schema.Schema as Schema
 import qualified Argo.Type.Config as Config
 import qualified Argo.Type.Decimal as Decimal
@@ -44,19 +45,28 @@ instance HasCodec Value.Value where
     codec = Codec.Codec
         { Codec.decode = Trans.ask
         , Codec.encode = Codec.tap $ Trans.lift . Trans.put
-        , Codec.schema = pure Schema.true
+        , Codec.schema = pure (Nothing, Schema.true)
         }
 
 instance HasCodec Null.Null where
     codec =
         let
-            schema :: Identity.Identity Schema.Schema
-            schema = pure . Schema.fromValue . Value.Object $ Object.fromList
-                [ Member.fromTuple
-                      ( Name.fromString . String.fromText $ Text.pack "type"
-                      , Value.String . String.fromText $ Text.pack "null"
-                      )
-                ]
+            schema
+                :: Identity.Identity
+                       (Maybe Identifier.Identifier, Schema.Schema)
+            schema =
+                pure
+                    . (,) Nothing
+                    . Schema.fromValue
+                    . Value.Object
+                    $ Object.fromList
+                          [ Member.fromTuple
+                                ( Name.fromString . String.fromText $ Text.pack
+                                    "type"
+                                , Value.String . String.fromText $ Text.pack
+                                    "null"
+                                )
+                          ]
         in basicCodec "Null" schema Value.Null $ \value -> case value of
             Value.Null null_ -> Just null_
             _ -> Nothing
@@ -64,13 +74,22 @@ instance HasCodec Null.Null where
 instance HasCodec Boolean.Boolean where
     codec =
         let
-            schema :: Identity.Identity Schema.Schema
-            schema = pure . Schema.fromValue . Value.Object $ Object.fromList
-                [ Member.fromTuple
-                      ( Name.fromString . String.fromText $ Text.pack "type"
-                      , Value.String . String.fromText $ Text.pack "boolean"
-                      )
-                ]
+            schema
+                :: Identity.Identity
+                       (Maybe Identifier.Identifier, Schema.Schema)
+            schema =
+                pure
+                    . (,) Nothing
+                    . Schema.fromValue
+                    . Value.Object
+                    $ Object.fromList
+                          [ Member.fromTuple
+                                ( Name.fromString . String.fromText $ Text.pack
+                                    "type"
+                                , Value.String . String.fromText $ Text.pack
+                                    "boolean"
+                                )
+                          ]
         in basicCodec "Boolean" schema Value.Boolean $ \value -> case value of
             Value.Boolean boolean -> Just boolean
             _ -> Nothing
@@ -78,13 +97,22 @@ instance HasCodec Boolean.Boolean where
 instance HasCodec Number.Number where
     codec =
         let
-            schema :: Identity.Identity Schema.Schema
-            schema = pure . Schema.fromValue . Value.Object $ Object.fromList
-                [ Member.fromTuple
-                      ( Name.fromString . String.fromText $ Text.pack "type"
-                      , Value.String . String.fromText $ Text.pack "number"
-                      )
-                ]
+            schema
+                :: Identity.Identity
+                       (Maybe Identifier.Identifier, Schema.Schema)
+            schema =
+                pure
+                    . (,) Nothing
+                    . Schema.fromValue
+                    . Value.Object
+                    $ Object.fromList
+                          [ Member.fromTuple
+                                ( Name.fromString . String.fromText $ Text.pack
+                                    "type"
+                                , Value.String . String.fromText $ Text.pack
+                                    "number"
+                                )
+                          ]
         in basicCodec "Number" schema Value.Number $ \value -> case value of
             Value.Number number -> Just number
             _ -> Nothing
@@ -92,13 +120,22 @@ instance HasCodec Number.Number where
 instance HasCodec String.String where
     codec =
         let
-            schema :: Identity.Identity Schema.Schema
-            schema = pure . Schema.fromValue . Value.Object $ Object.fromList
-                [ Member.fromTuple
-                      ( Name.fromString . String.fromText $ Text.pack "type"
-                      , Value.String . String.fromText $ Text.pack "string"
-                      )
-                ]
+            schema
+                :: Identity.Identity
+                       (Maybe Identifier.Identifier, Schema.Schema)
+            schema =
+                pure
+                    . (,) Nothing
+                    . Schema.fromValue
+                    . Value.Object
+                    $ Object.fromList
+                          [ Member.fromTuple
+                                ( Name.fromString . String.fromText $ Text.pack
+                                    "type"
+                                , Value.String . String.fromText $ Text.pack
+                                    "string"
+                                )
+                          ]
         in basicCodec "String" schema Value.String $ \value -> case value of
             Value.String string -> Just string
             _ -> Nothing
@@ -121,17 +158,23 @@ instance HasCodec a => HasCodec (Array.Array a) where
             . fmap (Codec.encodeWith codec)
             . Array.toList
         , Codec.schema = do
-            schema <- Codec.schema (codec :: Codec.Value a)
-            pure . Schema.fromValue . Value.Object $ Object.fromList
-                [ Member.fromTuple
-                    ( Name.fromString . String.fromText $ Text.pack "type"
-                    , Value.String . String.fromText $ Text.pack "array"
-                    )
-                , Member.fromTuple
-                    ( Name.fromString . String.fromText $ Text.pack "items"
-                    , Schema.toValue schema
-                    )
-                ]
+            (_, schema) <- Codec.schema (codec :: Codec.Value a)
+            pure
+                . (,) Nothing
+                . Schema.fromValue
+                . Value.Object
+                $ Object.fromList
+                      [ Member.fromTuple
+                          ( Name.fromString . String.fromText $ Text.pack
+                              "type"
+                          , Value.String . String.fromText $ Text.pack "array"
+                          )
+                      , Member.fromTuple
+                          ( Name.fromString . String.fromText $ Text.pack
+                              "items"
+                          , Schema.toValue schema
+                          )
+                      ]
         }
 
 instance HasCodec a => HasCodec (Object.Object a) where
@@ -158,18 +201,23 @@ instance HasCodec a => HasCodec (Object.Object a) where
                   )
             . Object.toList
         , Codec.schema = do
-            schema <- Codec.schema (codec :: Codec.Value a)
-            pure . Schema.fromValue . Value.Object $ Object.fromList
-                [ Member.fromTuple
-                    ( Name.fromString . String.fromText $ Text.pack "type"
-                    , Value.String . String.fromText $ Text.pack "object"
-                    )
-                , Member.fromTuple
-                    ( Name.fromString . String.fromText $ Text.pack
-                        "additionalProperties"
-                    , Schema.toValue schema
-                    )
-                ]
+            (_, schema) <- Codec.schema (codec :: Codec.Value a)
+            pure
+                . (,) Nothing
+                . Schema.fromValue
+                . Value.Object
+                $ Object.fromList
+                      [ Member.fromTuple
+                          ( Name.fromString . String.fromText $ Text.pack
+                              "type"
+                          , Value.String . String.fromText $ Text.pack "object"
+                          )
+                      , Member.fromTuple
+                          ( Name.fromString . String.fromText $ Text.pack
+                              "additionalProperties"
+                          , Schema.toValue schema
+                          )
+                      ]
         }
 
 instance HasCodec a => HasCodec (Maybe a) where
@@ -371,21 +419,36 @@ instance HasCodec String where
 instance HasCodec Char where
     codec =
         let
-            schema :: Identity.Identity Schema.Schema
-            schema = pure . Schema.fromValue . Value.Object $ Object.fromList
-                [ Member.fromTuple
-                    ( Name.fromString . String.fromText $ Text.pack "type"
-                    , Value.String . String.fromText $ Text.pack "string"
-                    )
-                , Member.fromTuple
-                    ( Name.fromString . String.fromText $ Text.pack "minLength"
-                    , Value.Number . Number.fromDecimal $ Decimal.fromInteger 1
-                    )
-                , Member.fromTuple
-                    ( Name.fromString . String.fromText $ Text.pack "maxLength"
-                    , Value.Number . Number.fromDecimal $ Decimal.fromInteger 1
-                    )
-                ]
+            schema
+                :: Identity.Identity
+                       (Maybe Identifier.Identifier, Schema.Schema)
+            schema =
+                pure
+                    . (,) Nothing
+                    . Schema.fromValue
+                    . Value.Object
+                    $ Object.fromList
+                          [ Member.fromTuple
+                              ( Name.fromString . String.fromText $ Text.pack
+                                  "type"
+                              , Value.String . String.fromText $ Text.pack
+                                  "string"
+                              )
+                          , Member.fromTuple
+                              ( Name.fromString . String.fromText $ Text.pack
+                                  "minLength"
+                              , Value.Number
+                              . Number.fromDecimal
+                              $ Decimal.fromInteger 1
+                              )
+                          , Member.fromTuple
+                              ( Name.fromString . String.fromText $ Text.pack
+                                  "maxLength"
+                              , Value.Number
+                              . Number.fromDecimal
+                              $ Decimal.fromInteger 1
+                              )
+                          ]
         in Codec.mapMaybe
             (\x -> case Text.uncons x of
                 Just (y, z) | Text.null z -> Just y
@@ -400,41 +463,59 @@ instance HasCodec Text.LazyText where
 instance HasCodec a => HasCodec (NonEmpty.NonEmpty a) where
     codec =
         let
+            schema
+                :: Identity.Identity
+                       (Maybe Identifier.Identifier, Schema.Schema)
             schema = do
-                itemSchema <- Codec.schema (codec :: Codec.Value a)
-                pure . Schema.fromValue . Value.Object $ Object.fromList
-                    [ Member.fromTuple
-                        ( Name.fromString . String.fromText $ Text.pack "type"
-                        , Value.String . String.fromText $ Text.pack "array"
-                        )
-                    , Member.fromTuple
-                        ( Name.fromString . String.fromText $ Text.pack "items"
-                        , Schema.toValue itemSchema
-                        )
-                    , Member.fromTuple
-                        ( Name.fromString . String.fromText $ Text.pack
-                            "minItems"
-                        , Value.Number
-                        . Number.fromDecimal
-                        $ Decimal.fromInteger 1
-                        )
-                    ]
-        in
-            Codec.mapMaybe
-                NonEmpty.nonEmpty
-                (Just . NonEmpty.toList)
-                codec { Codec.schema = schema }
+                (_, itemSchema) <- Codec.schema (codec :: Codec.Value a)
+                pure
+                    . (,) Nothing
+                    . Schema.fromValue
+                    . Value.Object
+                    $ Object.fromList
+                          [ Member.fromTuple
+                              ( Name.fromString . String.fromText $ Text.pack
+                                  "type"
+                              , Value.String . String.fromText $ Text.pack
+                                  "array"
+                              )
+                          , Member.fromTuple
+                              ( Name.fromString . String.fromText $ Text.pack
+                                  "items"
+                              , Schema.toValue itemSchema
+                              )
+                          , Member.fromTuple
+                              ( Name.fromString . String.fromText $ Text.pack
+                                  "minItems"
+                              , Value.Number
+                              . Number.fromDecimal
+                              $ Decimal.fromInteger 1
+                              )
+                          ]
+        in Codec.mapMaybe
+            NonEmpty.nonEmpty
+            (Just . NonEmpty.toList)
+            codec { Codec.schema = schema }
 
 instance HasCodec Integer where
     codec =
         let
-            schema :: Identity.Identity Schema.Schema
-            schema = pure . Schema.fromValue . Value.Object $ Object.fromList
-                [ Member.fromTuple
-                      ( Name.fromString . String.fromText $ Text.pack "type"
-                      , Value.String . String.fromText $ Text.pack "integer"
-                      )
-                ]
+            schema
+                :: Identity.Identity
+                       (Maybe Identifier.Identifier, Schema.Schema)
+            schema =
+                pure
+                    . (,) Nothing
+                    . Schema.fromValue
+                    . Value.Object
+                    $ Object.fromList
+                          [ Member.fromTuple
+                                ( Name.fromString . String.fromText $ Text.pack
+                                    "type"
+                                , Value.String . String.fromText $ Text.pack
+                                    "integer"
+                                )
+                          ]
         in Codec.mapMaybe
             Decimal.toInteger
             (Just . Decimal.fromInteger)
@@ -445,27 +526,38 @@ instance HasCodec Int where
         let
             from = Bits.toIntegralSized :: Integer -> Maybe Int
             into = fromIntegral :: Int -> Integer
-            schema :: Identity.Identity Schema.Schema
-            schema = pure . Schema.fromValue . Value.Object $ Object.fromList
-                [ Member.fromTuple
-                    ( Name.fromString . String.fromText $ Text.pack "type"
-                    , Value.String . String.fromText $ Text.pack "integer"
-                    )
-                , Member.fromTuple
-                    ( Name.fromString . String.fromText $ Text.pack "minimum"
-                    , Value.Number
-                    . Number.fromDecimal
-                    . Decimal.fromInteger
-                    $ toInteger (minBound :: Int)
-                    )
-                , Member.fromTuple
-                    ( Name.fromString . String.fromText $ Text.pack "maximum"
-                    , Value.Number
-                    . Number.fromDecimal
-                    . Decimal.fromInteger
-                    $ toInteger (maxBound :: Int)
-                    )
-                ]
+            schema
+                :: Identity.Identity
+                       (Maybe Identifier.Identifier, Schema.Schema)
+            schema =
+                pure
+                    . (,) Nothing
+                    . Schema.fromValue
+                    . Value.Object
+                    $ Object.fromList
+                          [ Member.fromTuple
+                              ( Name.fromString . String.fromText $ Text.pack
+                                  "type"
+                              , Value.String . String.fromText $ Text.pack
+                                  "integer"
+                              )
+                          , Member.fromTuple
+                              ( Name.fromString . String.fromText $ Text.pack
+                                  "minimum"
+                              , Value.Number
+                              . Number.fromDecimal
+                              . Decimal.fromInteger
+                              $ toInteger (minBound :: Int)
+                              )
+                          , Member.fromTuple
+                              ( Name.fromString . String.fromText $ Text.pack
+                                  "maximum"
+                              , Value.Number
+                              . Number.fromDecimal
+                              . Decimal.fromInteger
+                              $ toInteger (maxBound :: Int)
+                              )
+                          ]
         in Codec.mapMaybe from (Just . into) codec { Codec.schema = schema }
 
 instance HasCodec Int.Int8 where
@@ -473,27 +565,38 @@ instance HasCodec Int.Int8 where
         let
             from = Bits.toIntegralSized :: Integer -> Maybe Int.Int8
             into = fromIntegral :: Int.Int8 -> Integer
-            schema :: Identity.Identity Schema.Schema
-            schema = pure . Schema.fromValue . Value.Object $ Object.fromList
-                [ Member.fromTuple
-                    ( Name.fromString . String.fromText $ Text.pack "type"
-                    , Value.String . String.fromText $ Text.pack "integer"
-                    )
-                , Member.fromTuple
-                    ( Name.fromString . String.fromText $ Text.pack "minimum"
-                    , Value.Number
-                    . Number.fromDecimal
-                    . Decimal.fromInteger
-                    $ toInteger (minBound :: Int.Int8)
-                    )
-                , Member.fromTuple
-                    ( Name.fromString . String.fromText $ Text.pack "maximum"
-                    , Value.Number
-                    . Number.fromDecimal
-                    . Decimal.fromInteger
-                    $ toInteger (maxBound :: Int.Int8)
-                    )
-                ]
+            schema
+                :: Identity.Identity
+                       (Maybe Identifier.Identifier, Schema.Schema)
+            schema =
+                pure
+                    . (,) Nothing
+                    . Schema.fromValue
+                    . Value.Object
+                    $ Object.fromList
+                          [ Member.fromTuple
+                              ( Name.fromString . String.fromText $ Text.pack
+                                  "type"
+                              , Value.String . String.fromText $ Text.pack
+                                  "integer"
+                              )
+                          , Member.fromTuple
+                              ( Name.fromString . String.fromText $ Text.pack
+                                  "minimum"
+                              , Value.Number
+                              . Number.fromDecimal
+                              . Decimal.fromInteger
+                              $ toInteger (minBound :: Int.Int8)
+                              )
+                          , Member.fromTuple
+                              ( Name.fromString . String.fromText $ Text.pack
+                                  "maximum"
+                              , Value.Number
+                              . Number.fromDecimal
+                              . Decimal.fromInteger
+                              $ toInteger (maxBound :: Int.Int8)
+                              )
+                          ]
         in Codec.mapMaybe from (Just . into) codec { Codec.schema = schema }
 
 instance HasCodec Int.Int16 where
@@ -501,27 +604,38 @@ instance HasCodec Int.Int16 where
         let
             from = Bits.toIntegralSized :: Integer -> Maybe Int.Int16
             into = fromIntegral :: Int.Int16 -> Integer
-            schema :: Identity.Identity Schema.Schema
-            schema = pure . Schema.fromValue . Value.Object $ Object.fromList
-                [ Member.fromTuple
-                    ( Name.fromString . String.fromText $ Text.pack "type"
-                    , Value.String . String.fromText $ Text.pack "integer"
-                    )
-                , Member.fromTuple
-                    ( Name.fromString . String.fromText $ Text.pack "minimum"
-                    , Value.Number
-                    . Number.fromDecimal
-                    . Decimal.fromInteger
-                    $ toInteger (minBound :: Int.Int16)
-                    )
-                , Member.fromTuple
-                    ( Name.fromString . String.fromText $ Text.pack "maximum"
-                    , Value.Number
-                    . Number.fromDecimal
-                    . Decimal.fromInteger
-                    $ toInteger (maxBound :: Int.Int16)
-                    )
-                ]
+            schema
+                :: Identity.Identity
+                       (Maybe Identifier.Identifier, Schema.Schema)
+            schema =
+                pure
+                    . (,) Nothing
+                    . Schema.fromValue
+                    . Value.Object
+                    $ Object.fromList
+                          [ Member.fromTuple
+                              ( Name.fromString . String.fromText $ Text.pack
+                                  "type"
+                              , Value.String . String.fromText $ Text.pack
+                                  "integer"
+                              )
+                          , Member.fromTuple
+                              ( Name.fromString . String.fromText $ Text.pack
+                                  "minimum"
+                              , Value.Number
+                              . Number.fromDecimal
+                              . Decimal.fromInteger
+                              $ toInteger (minBound :: Int.Int16)
+                              )
+                          , Member.fromTuple
+                              ( Name.fromString . String.fromText $ Text.pack
+                                  "maximum"
+                              , Value.Number
+                              . Number.fromDecimal
+                              . Decimal.fromInteger
+                              $ toInteger (maxBound :: Int.Int16)
+                              )
+                          ]
         in Codec.mapMaybe from (Just . into) codec { Codec.schema = schema }
 
 instance HasCodec Int.Int32 where
@@ -529,27 +643,38 @@ instance HasCodec Int.Int32 where
         let
             from = Bits.toIntegralSized :: Integer -> Maybe Int.Int32
             into = fromIntegral :: Int.Int32 -> Integer
-            schema :: Identity.Identity Schema.Schema
-            schema = pure . Schema.fromValue . Value.Object $ Object.fromList
-                [ Member.fromTuple
-                    ( Name.fromString . String.fromText $ Text.pack "type"
-                    , Value.String . String.fromText $ Text.pack "integer"
-                    )
-                , Member.fromTuple
-                    ( Name.fromString . String.fromText $ Text.pack "minimum"
-                    , Value.Number
-                    . Number.fromDecimal
-                    . Decimal.fromInteger
-                    $ toInteger (minBound :: Int.Int32)
-                    )
-                , Member.fromTuple
-                    ( Name.fromString . String.fromText $ Text.pack "maximum"
-                    , Value.Number
-                    . Number.fromDecimal
-                    . Decimal.fromInteger
-                    $ toInteger (maxBound :: Int.Int32)
-                    )
-                ]
+            schema
+                :: Identity.Identity
+                       (Maybe Identifier.Identifier, Schema.Schema)
+            schema =
+                pure
+                    . (,) Nothing
+                    . Schema.fromValue
+                    . Value.Object
+                    $ Object.fromList
+                          [ Member.fromTuple
+                              ( Name.fromString . String.fromText $ Text.pack
+                                  "type"
+                              , Value.String . String.fromText $ Text.pack
+                                  "integer"
+                              )
+                          , Member.fromTuple
+                              ( Name.fromString . String.fromText $ Text.pack
+                                  "minimum"
+                              , Value.Number
+                              . Number.fromDecimal
+                              . Decimal.fromInteger
+                              $ toInteger (minBound :: Int.Int32)
+                              )
+                          , Member.fromTuple
+                              ( Name.fromString . String.fromText $ Text.pack
+                                  "maximum"
+                              , Value.Number
+                              . Number.fromDecimal
+                              . Decimal.fromInteger
+                              $ toInteger (maxBound :: Int.Int32)
+                              )
+                          ]
         in Codec.mapMaybe from (Just . into) codec { Codec.schema = schema }
 
 instance HasCodec Int.Int64 where
@@ -557,27 +682,38 @@ instance HasCodec Int.Int64 where
         let
             from = Bits.toIntegralSized :: Integer -> Maybe Int.Int64
             into = fromIntegral :: Int.Int64 -> Integer
-            schema :: Identity.Identity Schema.Schema
-            schema = pure . Schema.fromValue . Value.Object $ Object.fromList
-                [ Member.fromTuple
-                    ( Name.fromString . String.fromText $ Text.pack "type"
-                    , Value.String . String.fromText $ Text.pack "integer"
-                    )
-                , Member.fromTuple
-                    ( Name.fromString . String.fromText $ Text.pack "minimum"
-                    , Value.Number
-                    . Number.fromDecimal
-                    . Decimal.fromInteger
-                    $ toInteger (minBound :: Int.Int64)
-                    )
-                , Member.fromTuple
-                    ( Name.fromString . String.fromText $ Text.pack "maximum"
-                    , Value.Number
-                    . Number.fromDecimal
-                    . Decimal.fromInteger
-                    $ toInteger (maxBound :: Int.Int64)
-                    )
-                ]
+            schema
+                :: Identity.Identity
+                       (Maybe Identifier.Identifier, Schema.Schema)
+            schema =
+                pure
+                    . (,) Nothing
+                    . Schema.fromValue
+                    . Value.Object
+                    $ Object.fromList
+                          [ Member.fromTuple
+                              ( Name.fromString . String.fromText $ Text.pack
+                                  "type"
+                              , Value.String . String.fromText $ Text.pack
+                                  "integer"
+                              )
+                          , Member.fromTuple
+                              ( Name.fromString . String.fromText $ Text.pack
+                                  "minimum"
+                              , Value.Number
+                              . Number.fromDecimal
+                              . Decimal.fromInteger
+                              $ toInteger (minBound :: Int.Int64)
+                              )
+                          , Member.fromTuple
+                              ( Name.fromString . String.fromText $ Text.pack
+                                  "maximum"
+                              , Value.Number
+                              . Number.fromDecimal
+                              . Decimal.fromInteger
+                              $ toInteger (maxBound :: Int.Int64)
+                              )
+                          ]
         in Codec.mapMaybe from (Just . into) codec { Codec.schema = schema }
 
 instance HasCodec Natural.Natural where
@@ -585,17 +721,29 @@ instance HasCodec Natural.Natural where
         let
             from = Bits.toIntegralSized :: Integer -> Maybe Natural.Natural
             into = fromIntegral :: Natural.Natural -> Integer
-            schema :: Identity.Identity Schema.Schema
-            schema = pure . Schema.fromValue . Value.Object $ Object.fromList
-                [ Member.fromTuple
-                    ( Name.fromString . String.fromText $ Text.pack "type"
-                    , Value.String . String.fromText $ Text.pack "integer"
-                    )
-                , Member.fromTuple
-                    ( Name.fromString . String.fromText $ Text.pack "minimum"
-                    , Value.Number . Number.fromDecimal $ Decimal.fromInteger 0
-                    )
-                ]
+            schema
+                :: Identity.Identity
+                       (Maybe Identifier.Identifier, Schema.Schema)
+            schema =
+                pure
+                    . (,) Nothing
+                    . Schema.fromValue
+                    . Value.Object
+                    $ Object.fromList
+                          [ Member.fromTuple
+                              ( Name.fromString . String.fromText $ Text.pack
+                                  "type"
+                              , Value.String . String.fromText $ Text.pack
+                                  "integer"
+                              )
+                          , Member.fromTuple
+                              ( Name.fromString . String.fromText $ Text.pack
+                                  "minimum"
+                              , Value.Number
+                              . Number.fromDecimal
+                              $ Decimal.fromInteger 0
+                              )
+                          ]
         in Codec.mapMaybe from (Just . into) codec { Codec.schema = schema }
 
 instance HasCodec Word where
@@ -603,27 +751,38 @@ instance HasCodec Word where
         let
             from = Bits.toIntegralSized :: Integer -> Maybe Word
             into = fromIntegral :: Word -> Integer
-            schema :: Identity.Identity Schema.Schema
-            schema = pure . Schema.fromValue . Value.Object $ Object.fromList
-                [ Member.fromTuple
-                    ( Name.fromString . String.fromText $ Text.pack "type"
-                    , Value.String . String.fromText $ Text.pack "integer"
-                    )
-                , Member.fromTuple
-                    ( Name.fromString . String.fromText $ Text.pack "minimum"
-                    , Value.Number
-                    . Number.fromDecimal
-                    . Decimal.fromInteger
-                    $ toInteger (minBound :: Word)
-                    )
-                , Member.fromTuple
-                    ( Name.fromString . String.fromText $ Text.pack "maximum"
-                    , Value.Number
-                    . Number.fromDecimal
-                    . Decimal.fromInteger
-                    $ toInteger (maxBound :: Word)
-                    )
-                ]
+            schema
+                :: Identity.Identity
+                       (Maybe Identifier.Identifier, Schema.Schema)
+            schema =
+                pure
+                    . (,) Nothing
+                    . Schema.fromValue
+                    . Value.Object
+                    $ Object.fromList
+                          [ Member.fromTuple
+                              ( Name.fromString . String.fromText $ Text.pack
+                                  "type"
+                              , Value.String . String.fromText $ Text.pack
+                                  "integer"
+                              )
+                          , Member.fromTuple
+                              ( Name.fromString . String.fromText $ Text.pack
+                                  "minimum"
+                              , Value.Number
+                              . Number.fromDecimal
+                              . Decimal.fromInteger
+                              $ toInteger (minBound :: Word)
+                              )
+                          , Member.fromTuple
+                              ( Name.fromString . String.fromText $ Text.pack
+                                  "maximum"
+                              , Value.Number
+                              . Number.fromDecimal
+                              . Decimal.fromInteger
+                              $ toInteger (maxBound :: Word)
+                              )
+                          ]
         in Codec.mapMaybe from (Just . into) codec { Codec.schema = schema }
 
 instance HasCodec Word.Word8 where
@@ -631,27 +790,38 @@ instance HasCodec Word.Word8 where
         let
             from = Bits.toIntegralSized :: Integer -> Maybe Word.Word8
             into = fromIntegral :: Word.Word8 -> Integer
-            schema :: Identity.Identity Schema.Schema
-            schema = pure . Schema.fromValue . Value.Object $ Object.fromList
-                [ Member.fromTuple
-                    ( Name.fromString . String.fromText $ Text.pack "type"
-                    , Value.String . String.fromText $ Text.pack "integer"
-                    )
-                , Member.fromTuple
-                    ( Name.fromString . String.fromText $ Text.pack "minimum"
-                    , Value.Number
-                    . Number.fromDecimal
-                    . Decimal.fromInteger
-                    $ toInteger (minBound :: Word.Word8)
-                    )
-                , Member.fromTuple
-                    ( Name.fromString . String.fromText $ Text.pack "maximum"
-                    , Value.Number
-                    . Number.fromDecimal
-                    . Decimal.fromInteger
-                    $ toInteger (maxBound :: Word.Word8)
-                    )
-                ]
+            schema
+                :: Identity.Identity
+                       (Maybe Identifier.Identifier, Schema.Schema)
+            schema =
+                pure
+                    . (,) Nothing
+                    . Schema.fromValue
+                    . Value.Object
+                    $ Object.fromList
+                          [ Member.fromTuple
+                              ( Name.fromString . String.fromText $ Text.pack
+                                  "type"
+                              , Value.String . String.fromText $ Text.pack
+                                  "integer"
+                              )
+                          , Member.fromTuple
+                              ( Name.fromString . String.fromText $ Text.pack
+                                  "minimum"
+                              , Value.Number
+                              . Number.fromDecimal
+                              . Decimal.fromInteger
+                              $ toInteger (minBound :: Word.Word8)
+                              )
+                          , Member.fromTuple
+                              ( Name.fromString . String.fromText $ Text.pack
+                                  "maximum"
+                              , Value.Number
+                              . Number.fromDecimal
+                              . Decimal.fromInteger
+                              $ toInteger (maxBound :: Word.Word8)
+                              )
+                          ]
         in Codec.mapMaybe from (Just . into) codec { Codec.schema = schema }
 
 instance HasCodec Word.Word16 where
@@ -659,27 +829,38 @@ instance HasCodec Word.Word16 where
         let
             from = Bits.toIntegralSized :: Integer -> Maybe Word.Word16
             into = fromIntegral :: Word.Word16 -> Integer
-            schema :: Identity.Identity Schema.Schema
-            schema = pure . Schema.fromValue . Value.Object $ Object.fromList
-                [ Member.fromTuple
-                    ( Name.fromString . String.fromText $ Text.pack "type"
-                    , Value.String . String.fromText $ Text.pack "integer"
-                    )
-                , Member.fromTuple
-                    ( Name.fromString . String.fromText $ Text.pack "minimum"
-                    , Value.Number
-                    . Number.fromDecimal
-                    . Decimal.fromInteger
-                    $ toInteger (minBound :: Word.Word16)
-                    )
-                , Member.fromTuple
-                    ( Name.fromString . String.fromText $ Text.pack "maximum"
-                    , Value.Number
-                    . Number.fromDecimal
-                    . Decimal.fromInteger
-                    $ toInteger (maxBound :: Word.Word16)
-                    )
-                ]
+            schema
+                :: Identity.Identity
+                       (Maybe Identifier.Identifier, Schema.Schema)
+            schema =
+                pure
+                    . (,) Nothing
+                    . Schema.fromValue
+                    . Value.Object
+                    $ Object.fromList
+                          [ Member.fromTuple
+                              ( Name.fromString . String.fromText $ Text.pack
+                                  "type"
+                              , Value.String . String.fromText $ Text.pack
+                                  "integer"
+                              )
+                          , Member.fromTuple
+                              ( Name.fromString . String.fromText $ Text.pack
+                                  "minimum"
+                              , Value.Number
+                              . Number.fromDecimal
+                              . Decimal.fromInteger
+                              $ toInteger (minBound :: Word.Word16)
+                              )
+                          , Member.fromTuple
+                              ( Name.fromString . String.fromText $ Text.pack
+                                  "maximum"
+                              , Value.Number
+                              . Number.fromDecimal
+                              . Decimal.fromInteger
+                              $ toInteger (maxBound :: Word.Word16)
+                              )
+                          ]
         in Codec.mapMaybe from (Just . into) codec { Codec.schema = schema }
 
 instance HasCodec Word.Word32 where
@@ -687,27 +868,38 @@ instance HasCodec Word.Word32 where
         let
             from = Bits.toIntegralSized :: Integer -> Maybe Word.Word32
             into = fromIntegral :: Word.Word32 -> Integer
-            schema :: Identity.Identity Schema.Schema
-            schema = pure . Schema.fromValue . Value.Object $ Object.fromList
-                [ Member.fromTuple
-                    ( Name.fromString . String.fromText $ Text.pack "type"
-                    , Value.String . String.fromText $ Text.pack "integer"
-                    )
-                , Member.fromTuple
-                    ( Name.fromString . String.fromText $ Text.pack "minimum"
-                    , Value.Number
-                    . Number.fromDecimal
-                    . Decimal.fromInteger
-                    $ toInteger (minBound :: Word.Word32)
-                    )
-                , Member.fromTuple
-                    ( Name.fromString . String.fromText $ Text.pack "maximum"
-                    , Value.Number
-                    . Number.fromDecimal
-                    . Decimal.fromInteger
-                    $ toInteger (maxBound :: Word.Word32)
-                    )
-                ]
+            schema
+                :: Identity.Identity
+                       (Maybe Identifier.Identifier, Schema.Schema)
+            schema =
+                pure
+                    . (,) Nothing
+                    . Schema.fromValue
+                    . Value.Object
+                    $ Object.fromList
+                          [ Member.fromTuple
+                              ( Name.fromString . String.fromText $ Text.pack
+                                  "type"
+                              , Value.String . String.fromText $ Text.pack
+                                  "integer"
+                              )
+                          , Member.fromTuple
+                              ( Name.fromString . String.fromText $ Text.pack
+                                  "minimum"
+                              , Value.Number
+                              . Number.fromDecimal
+                              . Decimal.fromInteger
+                              $ toInteger (minBound :: Word.Word32)
+                              )
+                          , Member.fromTuple
+                              ( Name.fromString . String.fromText $ Text.pack
+                                  "maximum"
+                              , Value.Number
+                              . Number.fromDecimal
+                              . Decimal.fromInteger
+                              $ toInteger (maxBound :: Word.Word32)
+                              )
+                          ]
         in Codec.mapMaybe from (Just . into) codec { Codec.schema = schema }
 
 instance HasCodec Word.Word64 where
@@ -715,27 +907,38 @@ instance HasCodec Word.Word64 where
         let
             from = Bits.toIntegralSized :: Integer -> Maybe Word.Word64
             into = fromIntegral :: Word.Word64 -> Integer
-            schema :: Identity.Identity Schema.Schema
-            schema = pure . Schema.fromValue . Value.Object $ Object.fromList
-                [ Member.fromTuple
-                    ( Name.fromString . String.fromText $ Text.pack "type"
-                    , Value.String . String.fromText $ Text.pack "integer"
-                    )
-                , Member.fromTuple
-                    ( Name.fromString . String.fromText $ Text.pack "minimum"
-                    , Value.Number
-                    . Number.fromDecimal
-                    . Decimal.fromInteger
-                    $ toInteger (minBound :: Word.Word64)
-                    )
-                , Member.fromTuple
-                    ( Name.fromString . String.fromText $ Text.pack "maximum"
-                    , Value.Number
-                    . Number.fromDecimal
-                    . Decimal.fromInteger
-                    $ toInteger (maxBound :: Word.Word64)
-                    )
-                ]
+            schema
+                :: Identity.Identity
+                       (Maybe Identifier.Identifier, Schema.Schema)
+            schema =
+                pure
+                    . (,) Nothing
+                    . Schema.fromValue
+                    . Value.Object
+                    $ Object.fromList
+                          [ Member.fromTuple
+                              ( Name.fromString . String.fromText $ Text.pack
+                                  "type"
+                              , Value.String . String.fromText $ Text.pack
+                                  "integer"
+                              )
+                          , Member.fromTuple
+                              ( Name.fromString . String.fromText $ Text.pack
+                                  "minimum"
+                              , Value.Number
+                              . Number.fromDecimal
+                              . Decimal.fromInteger
+                              $ toInteger (minBound :: Word.Word64)
+                              )
+                          , Member.fromTuple
+                              ( Name.fromString . String.fromText $ Text.pack
+                                  "maximum"
+                              , Value.Number
+                              . Number.fromDecimal
+                              . Decimal.fromInteger
+                              $ toInteger (maxBound :: Word.Word64)
+                              )
+                          ]
         in Codec.mapMaybe from (Just . into) codec { Codec.schema = schema }
 
 instance HasCodec Float where
@@ -766,7 +969,7 @@ instance HasCodec Schema.Schema where
 
 basicCodec
     :: String
-    -> Identity.Identity Schema.Schema
+    -> Identity.Identity (Maybe Identifier.Identifier, Schema.Schema)
     -> (a -> Value.Value)
     -> (Value.Value -> Maybe a)
     -> Codec.Value a

--- a/source/library/Argo/Class/HasCodec.hs
+++ b/source/library/Argo/Class/HasCodec.hs
@@ -52,7 +52,9 @@ instance HasCodec Null.Null where
     codec =
         let
             schema
-                :: Identity.Identity
+                :: Trans.AccumT
+                       ()
+                       Identity.Identity
                        (Maybe Identifier.Identifier, Schema.Schema)
             schema =
                 pure
@@ -75,7 +77,9 @@ instance HasCodec Boolean.Boolean where
     codec =
         let
             schema
-                :: Identity.Identity
+                :: Trans.AccumT
+                       ()
+                       Identity.Identity
                        (Maybe Identifier.Identifier, Schema.Schema)
             schema =
                 pure
@@ -98,7 +102,9 @@ instance HasCodec Number.Number where
     codec =
         let
             schema
-                :: Identity.Identity
+                :: Trans.AccumT
+                       ()
+                       Identity.Identity
                        (Maybe Identifier.Identifier, Schema.Schema)
             schema =
                 pure
@@ -121,7 +127,9 @@ instance HasCodec String.String where
     codec =
         let
             schema
-                :: Identity.Identity
+                :: Trans.AccumT
+                       ()
+                       Identity.Identity
                        (Maybe Identifier.Identifier, Schema.Schema)
             schema =
                 pure
@@ -420,7 +428,9 @@ instance HasCodec Char where
     codec =
         let
             schema
-                :: Identity.Identity
+                :: Trans.AccumT
+                       ()
+                       Identity.Identity
                        (Maybe Identifier.Identifier, Schema.Schema)
             schema =
                 pure
@@ -464,7 +474,9 @@ instance HasCodec a => HasCodec (NonEmpty.NonEmpty a) where
     codec =
         let
             schema
-                :: Identity.Identity
+                :: Trans.AccumT
+                       ()
+                       Identity.Identity
                        (Maybe Identifier.Identifier, Schema.Schema)
             schema = do
                 (_, itemSchema) <- Codec.schema (codec :: Codec.Value a)
@@ -501,7 +513,9 @@ instance HasCodec Integer where
     codec =
         let
             schema
-                :: Identity.Identity
+                :: Trans.AccumT
+                       ()
+                       Identity.Identity
                        (Maybe Identifier.Identifier, Schema.Schema)
             schema =
                 pure
@@ -527,7 +541,9 @@ instance HasCodec Int where
             from = Bits.toIntegralSized :: Integer -> Maybe Int
             into = fromIntegral :: Int -> Integer
             schema
-                :: Identity.Identity
+                :: Trans.AccumT
+                       ()
+                       Identity.Identity
                        (Maybe Identifier.Identifier, Schema.Schema)
             schema =
                 pure
@@ -566,7 +582,9 @@ instance HasCodec Int.Int8 where
             from = Bits.toIntegralSized :: Integer -> Maybe Int.Int8
             into = fromIntegral :: Int.Int8 -> Integer
             schema
-                :: Identity.Identity
+                :: Trans.AccumT
+                       ()
+                       Identity.Identity
                        (Maybe Identifier.Identifier, Schema.Schema)
             schema =
                 pure
@@ -605,7 +623,9 @@ instance HasCodec Int.Int16 where
             from = Bits.toIntegralSized :: Integer -> Maybe Int.Int16
             into = fromIntegral :: Int.Int16 -> Integer
             schema
-                :: Identity.Identity
+                :: Trans.AccumT
+                       ()
+                       Identity.Identity
                        (Maybe Identifier.Identifier, Schema.Schema)
             schema =
                 pure
@@ -644,7 +664,9 @@ instance HasCodec Int.Int32 where
             from = Bits.toIntegralSized :: Integer -> Maybe Int.Int32
             into = fromIntegral :: Int.Int32 -> Integer
             schema
-                :: Identity.Identity
+                :: Trans.AccumT
+                       ()
+                       Identity.Identity
                        (Maybe Identifier.Identifier, Schema.Schema)
             schema =
                 pure
@@ -683,7 +705,9 @@ instance HasCodec Int.Int64 where
             from = Bits.toIntegralSized :: Integer -> Maybe Int.Int64
             into = fromIntegral :: Int.Int64 -> Integer
             schema
-                :: Identity.Identity
+                :: Trans.AccumT
+                       ()
+                       Identity.Identity
                        (Maybe Identifier.Identifier, Schema.Schema)
             schema =
                 pure
@@ -722,7 +746,9 @@ instance HasCodec Natural.Natural where
             from = Bits.toIntegralSized :: Integer -> Maybe Natural.Natural
             into = fromIntegral :: Natural.Natural -> Integer
             schema
-                :: Identity.Identity
+                :: Trans.AccumT
+                       ()
+                       Identity.Identity
                        (Maybe Identifier.Identifier, Schema.Schema)
             schema =
                 pure
@@ -752,7 +778,9 @@ instance HasCodec Word where
             from = Bits.toIntegralSized :: Integer -> Maybe Word
             into = fromIntegral :: Word -> Integer
             schema
-                :: Identity.Identity
+                :: Trans.AccumT
+                       ()
+                       Identity.Identity
                        (Maybe Identifier.Identifier, Schema.Schema)
             schema =
                 pure
@@ -791,7 +819,9 @@ instance HasCodec Word.Word8 where
             from = Bits.toIntegralSized :: Integer -> Maybe Word.Word8
             into = fromIntegral :: Word.Word8 -> Integer
             schema
-                :: Identity.Identity
+                :: Trans.AccumT
+                       ()
+                       Identity.Identity
                        (Maybe Identifier.Identifier, Schema.Schema)
             schema =
                 pure
@@ -830,7 +860,9 @@ instance HasCodec Word.Word16 where
             from = Bits.toIntegralSized :: Integer -> Maybe Word.Word16
             into = fromIntegral :: Word.Word16 -> Integer
             schema
-                :: Identity.Identity
+                :: Trans.AccumT
+                       ()
+                       Identity.Identity
                        (Maybe Identifier.Identifier, Schema.Schema)
             schema =
                 pure
@@ -869,7 +901,9 @@ instance HasCodec Word.Word32 where
             from = Bits.toIntegralSized :: Integer -> Maybe Word.Word32
             into = fromIntegral :: Word.Word32 -> Integer
             schema
-                :: Identity.Identity
+                :: Trans.AccumT
+                       ()
+                       Identity.Identity
                        (Maybe Identifier.Identifier, Schema.Schema)
             schema =
                 pure
@@ -908,7 +942,9 @@ instance HasCodec Word.Word64 where
             from = Bits.toIntegralSized :: Integer -> Maybe Word.Word64
             into = fromIntegral :: Word.Word64 -> Integer
             schema
-                :: Identity.Identity
+                :: Trans.AccumT
+                       ()
+                       Identity.Identity
                        (Maybe Identifier.Identifier, Schema.Schema)
             schema =
                 pure
@@ -969,7 +1005,10 @@ instance HasCodec Schema.Schema where
 
 basicCodec
     :: String
-    -> Identity.Identity (Maybe Identifier.Identifier, Schema.Schema)
+    -> Trans.AccumT
+           ()
+           Identity.Identity
+           (Maybe Identifier.Identifier, Schema.Schema)
     -> (a -> Value.Value)
     -> (Value.Value -> Maybe a)
     -> Codec.Value a

--- a/source/library/Argo/Class/HasCodec.hs
+++ b/source/library/Argo/Class/HasCodec.hs
@@ -53,7 +53,7 @@ instance HasCodec Null.Null where
         let
             schema
                 :: Trans.AccumT
-                       ()
+                       (Map.Map Identifier.Identifier Schema.Schema)
                        Identity.Identity
                        (Maybe Identifier.Identifier, Schema.Schema)
             schema =
@@ -78,7 +78,7 @@ instance HasCodec Boolean.Boolean where
         let
             schema
                 :: Trans.AccumT
-                       ()
+                       (Map.Map Identifier.Identifier Schema.Schema)
                        Identity.Identity
                        (Maybe Identifier.Identifier, Schema.Schema)
             schema =
@@ -103,7 +103,7 @@ instance HasCodec Number.Number where
         let
             schema
                 :: Trans.AccumT
-                       ()
+                       (Map.Map Identifier.Identifier Schema.Schema)
                        Identity.Identity
                        (Maybe Identifier.Identifier, Schema.Schema)
             schema =
@@ -128,7 +128,7 @@ instance HasCodec String.String where
         let
             schema
                 :: Trans.AccumT
-                       ()
+                       (Map.Map Identifier.Identifier Schema.Schema)
                        Identity.Identity
                        (Maybe Identifier.Identifier, Schema.Schema)
             schema =
@@ -429,7 +429,7 @@ instance HasCodec Char where
         let
             schema
                 :: Trans.AccumT
-                       ()
+                       (Map.Map Identifier.Identifier Schema.Schema)
                        Identity.Identity
                        (Maybe Identifier.Identifier, Schema.Schema)
             schema =
@@ -475,7 +475,7 @@ instance HasCodec a => HasCodec (NonEmpty.NonEmpty a) where
         let
             schema
                 :: Trans.AccumT
-                       ()
+                       (Map.Map Identifier.Identifier Schema.Schema)
                        Identity.Identity
                        (Maybe Identifier.Identifier, Schema.Schema)
             schema = do
@@ -514,7 +514,7 @@ instance HasCodec Integer where
         let
             schema
                 :: Trans.AccumT
-                       ()
+                       (Map.Map Identifier.Identifier Schema.Schema)
                        Identity.Identity
                        (Maybe Identifier.Identifier, Schema.Schema)
             schema =
@@ -542,7 +542,7 @@ instance HasCodec Int where
             into = fromIntegral :: Int -> Integer
             schema
                 :: Trans.AccumT
-                       ()
+                       (Map.Map Identifier.Identifier Schema.Schema)
                        Identity.Identity
                        (Maybe Identifier.Identifier, Schema.Schema)
             schema =
@@ -583,7 +583,7 @@ instance HasCodec Int.Int8 where
             into = fromIntegral :: Int.Int8 -> Integer
             schema
                 :: Trans.AccumT
-                       ()
+                       (Map.Map Identifier.Identifier Schema.Schema)
                        Identity.Identity
                        (Maybe Identifier.Identifier, Schema.Schema)
             schema =
@@ -624,7 +624,7 @@ instance HasCodec Int.Int16 where
             into = fromIntegral :: Int.Int16 -> Integer
             schema
                 :: Trans.AccumT
-                       ()
+                       (Map.Map Identifier.Identifier Schema.Schema)
                        Identity.Identity
                        (Maybe Identifier.Identifier, Schema.Schema)
             schema =
@@ -665,7 +665,7 @@ instance HasCodec Int.Int32 where
             into = fromIntegral :: Int.Int32 -> Integer
             schema
                 :: Trans.AccumT
-                       ()
+                       (Map.Map Identifier.Identifier Schema.Schema)
                        Identity.Identity
                        (Maybe Identifier.Identifier, Schema.Schema)
             schema =
@@ -706,7 +706,7 @@ instance HasCodec Int.Int64 where
             into = fromIntegral :: Int.Int64 -> Integer
             schema
                 :: Trans.AccumT
-                       ()
+                       (Map.Map Identifier.Identifier Schema.Schema)
                        Identity.Identity
                        (Maybe Identifier.Identifier, Schema.Schema)
             schema =
@@ -747,7 +747,7 @@ instance HasCodec Natural.Natural where
             into = fromIntegral :: Natural.Natural -> Integer
             schema
                 :: Trans.AccumT
-                       ()
+                       (Map.Map Identifier.Identifier Schema.Schema)
                        Identity.Identity
                        (Maybe Identifier.Identifier, Schema.Schema)
             schema =
@@ -779,7 +779,7 @@ instance HasCodec Word where
             into = fromIntegral :: Word -> Integer
             schema
                 :: Trans.AccumT
-                       ()
+                       (Map.Map Identifier.Identifier Schema.Schema)
                        Identity.Identity
                        (Maybe Identifier.Identifier, Schema.Schema)
             schema =
@@ -820,7 +820,7 @@ instance HasCodec Word.Word8 where
             into = fromIntegral :: Word.Word8 -> Integer
             schema
                 :: Trans.AccumT
-                       ()
+                       (Map.Map Identifier.Identifier Schema.Schema)
                        Identity.Identity
                        (Maybe Identifier.Identifier, Schema.Schema)
             schema =
@@ -861,7 +861,7 @@ instance HasCodec Word.Word16 where
             into = fromIntegral :: Word.Word16 -> Integer
             schema
                 :: Trans.AccumT
-                       ()
+                       (Map.Map Identifier.Identifier Schema.Schema)
                        Identity.Identity
                        (Maybe Identifier.Identifier, Schema.Schema)
             schema =
@@ -902,7 +902,7 @@ instance HasCodec Word.Word32 where
             into = fromIntegral :: Word.Word32 -> Integer
             schema
                 :: Trans.AccumT
-                       ()
+                       (Map.Map Identifier.Identifier Schema.Schema)
                        Identity.Identity
                        (Maybe Identifier.Identifier, Schema.Schema)
             schema =
@@ -943,7 +943,7 @@ instance HasCodec Word.Word64 where
             into = fromIntegral :: Word.Word64 -> Integer
             schema
                 :: Trans.AccumT
-                       ()
+                       (Map.Map Identifier.Identifier Schema.Schema)
                        Identity.Identity
                        (Maybe Identifier.Identifier, Schema.Schema)
             schema =
@@ -1006,7 +1006,7 @@ instance HasCodec Schema.Schema where
 basicCodec
     :: String
     -> Trans.AccumT
-           ()
+           (Map.Map Identifier.Identifier Schema.Schema)
            Identity.Identity
            (Maybe Identifier.Identifier, Schema.Schema)
     -> (a -> Value.Value)

--- a/source/library/Argo/Codec/Array.hs
+++ b/source/library/Argo/Codec/Array.hs
@@ -19,11 +19,11 @@ import qualified Data.Functor.Identity as Identity
 
 type Array a
     = Codec.List
-          [ Trans.AccumT
+          ( Trans.AccumT
                 ()
                 Identity.Identity
-                (Maybe Identifier.Identifier, Schema.Schema)
-          ]
+                [(Maybe Identifier.Identifier, Schema.Schema)]
+          )
           Value.Value
           a
 
@@ -31,7 +31,7 @@ fromArrayCodec :: Permission.Permission -> Array a -> Codec.Value a
 fromArrayCodec =
     Codec.fromListCodec
             (\permission schemasM -> do
-                schemas <- sequence schemasM
+                schemas <- schemasM
                 pure
                     . (,) Nothing
                     . Schema.fromValue
@@ -77,5 +77,5 @@ element c = Codec.Codec
     , Codec.encode = \x -> do
         Trans.tell [Codec.encodeWith c x]
         pure x
-    , Codec.schema = [Codec.schema c]
+    , Codec.schema = pure <$> Codec.schema c
     }

--- a/source/library/Argo/Codec/Array.hs
+++ b/source/library/Argo/Codec/Array.hs
@@ -14,14 +14,16 @@ import qualified Argo.Schema.Schema as Schema
 import qualified Argo.Type.Permission as Permission
 import qualified Argo.Vendor.Text as Text
 import qualified Argo.Vendor.Transformers as Trans
+import qualified Data.Functor.Identity as Identity
 
-type Array a = Codec.List [Schema.Schema] Value.Value a
+type Array a = Codec.List [Identity.Identity Schema.Schema] Value.Value a
 
 fromArrayCodec :: Permission.Permission -> Array a -> Codec.Value a
 fromArrayCodec =
     Codec.fromListCodec
-            (\permission schemas ->
-                Schema.fromValue . Value.Object $ Object.fromList
+            (\permission schemasM -> do
+                schemas <- sequence schemasM
+                pure . Schema.fromValue . Value.Object $ Object.fromList
                     [ Member.fromTuple
                         ( Name.fromString . String.fromText $ Text.pack "type"
                         , Value.String . String.fromText $ Text.pack "array"

--- a/source/library/Argo/Codec/Array.hs
+++ b/source/library/Argo/Codec/Array.hs
@@ -10,38 +10,52 @@ import qualified Argo.Json.Name as Name
 import qualified Argo.Json.Object as Object
 import qualified Argo.Json.String as String
 import qualified Argo.Json.Value as Value
+import qualified Argo.Schema.Identifier as Identifier
 import qualified Argo.Schema.Schema as Schema
 import qualified Argo.Type.Permission as Permission
 import qualified Argo.Vendor.Text as Text
 import qualified Argo.Vendor.Transformers as Trans
 import qualified Data.Functor.Identity as Identity
 
-type Array a = Codec.List [Identity.Identity Schema.Schema] Value.Value a
+type Array a
+    = Codec.List
+          [Identity.Identity (Maybe Identifier.Identifier, Schema.Schema)]
+          Value.Value
+          a
 
 fromArrayCodec :: Permission.Permission -> Array a -> Codec.Value a
 fromArrayCodec =
     Codec.fromListCodec
             (\permission schemasM -> do
                 schemas <- sequence schemasM
-                pure . Schema.fromValue . Value.Object $ Object.fromList
-                    [ Member.fromTuple
-                        ( Name.fromString . String.fromText $ Text.pack "type"
-                        , Value.String . String.fromText $ Text.pack "array"
-                        )
-                    , Member.fromTuple
-                        ( Name.fromString . String.fromText $ Text.pack "items"
-                        , Value.Array . Array.fromList $ fmap
-                            Schema.toValue
-                            schemas
-                        )
-                    , Member.fromTuple
-                        ( Name.fromString . String.fromText $ Text.pack
-                            "additionalItems"
-                        , Value.Boolean . Boolean.fromBool $ case permission of
-                            Permission.Allow -> True
-                            Permission.Forbid -> False
-                        )
-                    ]
+                pure
+                    . (,) Nothing
+                    . Schema.fromValue
+                    . Value.Object
+                    $ Object.fromList
+                          [ Member.fromTuple
+                              ( Name.fromString . String.fromText $ Text.pack
+                                  "type"
+                              , Value.String . String.fromText $ Text.pack
+                                  "array"
+                              )
+                          , Member.fromTuple
+                              ( Name.fromString . String.fromText $ Text.pack
+                                  "items"
+                              , Value.Array . Array.fromList $ fmap
+                                  (Schema.toValue . snd)
+                                  schemas
+                              )
+                          , Member.fromTuple
+                              ( Name.fromString . String.fromText $ Text.pack
+                                  "additionalItems"
+                              , Value.Boolean
+                              . Boolean.fromBool
+                              $ case permission of
+                                    Permission.Allow -> True
+                                    Permission.Forbid -> False
+                              )
+                          ]
             )
         $ Codec.map Array.toList Array.fromList Codec.arrayCodec
 

--- a/source/library/Argo/Codec/Array.hs
+++ b/source/library/Argo/Codec/Array.hs
@@ -34,7 +34,7 @@ fromArrayCodec =
             (\permission schemasM -> do
                 schemas <- schemasM
                 pure
-                    . (,) Nothing
+                    . Schema.unidentified
                     . Schema.fromValue
                     . Value.Object
                     $ Object.fromList
@@ -78,5 +78,10 @@ element c = Codec.Codec
     , Codec.encode = \x -> do
         Trans.tell [Codec.encodeWith c x]
         pure x
-    , Codec.schema = pure <$> Codec.schema c
+    , Codec.schema =
+        pure
+        . Schema.unidentified
+        . Schema.fromValue
+        . Codec.ref
+        <$> Codec.getRef c
     }

--- a/source/library/Argo/Codec/Array.hs
+++ b/source/library/Argo/Codec/Array.hs
@@ -19,7 +19,11 @@ import qualified Data.Functor.Identity as Identity
 
 type Array a
     = Codec.List
-          [Identity.Identity (Maybe Identifier.Identifier, Schema.Schema)]
+          [ Trans.AccumT
+                ()
+                Identity.Identity
+                (Maybe Identifier.Identifier, Schema.Schema)
+          ]
           Value.Value
           a
 

--- a/source/library/Argo/Codec/Array.hs
+++ b/source/library/Argo/Codec/Array.hs
@@ -13,6 +13,7 @@ import qualified Argo.Json.Value as Value
 import qualified Argo.Schema.Identifier as Identifier
 import qualified Argo.Schema.Schema as Schema
 import qualified Argo.Type.Permission as Permission
+import qualified Argo.Vendor.Map as Map
 import qualified Argo.Vendor.Text as Text
 import qualified Argo.Vendor.Transformers as Trans
 import qualified Data.Functor.Identity as Identity
@@ -20,7 +21,7 @@ import qualified Data.Functor.Identity as Identity
 type Array a
     = Codec.List
           ( Trans.AccumT
-                ()
+                (Map.Map Identifier.Identifier Schema.Schema)
                 Identity.Identity
                 [(Maybe Identifier.Identifier, Schema.Schema)]
           )

--- a/source/library/Argo/Codec/Codec.hs
+++ b/source/library/Argo/Codec/Codec.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE FlexibleInstances #-}
+
 module Argo.Codec.Codec where
 
 import Control.Applicative ((<|>))
@@ -20,31 +22,35 @@ instance (Functor r, Functor w) => Functor (Codec r w s i) where
 instance
     ( Applicative r
     , Applicative w
-    ) => Applicative (Codec r w s i) where
+    , Applicative s
+    , Monoid a
+    ) => Applicative (Codec r w (s a) i) where
     pure x = Codec
         { decode = pure x
         , encode = const $ pure x
-        , schema = error "TODO"
+        , schema = pure mempty
         }
     cf <*> cx = Codec
         { decode = decode cf <*> decode cx
         , encode = \i -> encode cf i <*> encode cx i
-        , schema = error "TODO"
+        , schema = (<>) <$> schema cf <*> schema cx
         }
 
 instance
     ( Applicative.Alternative r
     , Applicative.Alternative w
-    ) => Applicative.Alternative (Codec r w s i) where
+    , Applicative s
+    , Monoid a
+    ) => Applicative.Alternative (Codec r w (s a) i) where
     empty = Codec
         { decode = Applicative.empty
         , encode = const Applicative.empty
-        , schema = error "TODO"
+        , schema = pure mempty
         }
     cx <|> cy = Codec
         { decode = decode cx <|> decode cy
         , encode = \i -> encode cx i <|> encode cy i
-        , schema = error "TODO"
+        , schema = (<>) <$> schema cx <*> schema cy
         }
 
 map

--- a/source/library/Argo/Codec/Codec.hs
+++ b/source/library/Argo/Codec/Codec.hs
@@ -20,30 +20,31 @@ instance (Functor r, Functor w) => Functor (Codec r w s i) where
 instance
     ( Applicative r
     , Applicative w
-    , Monoid s
     ) => Applicative (Codec r w s i) where
-    pure x =
-        Codec { decode = pure x, encode = const $ pure x, schema = mempty }
+    pure x = Codec
+        { decode = pure x
+        , encode = const $ pure x
+        , schema = error "TODO"
+        }
     cf <*> cx = Codec
         { decode = decode cf <*> decode cx
         , encode = \i -> encode cf i <*> encode cx i
-        , schema = schema cf <> schema cx
+        , schema = error "TODO"
         }
 
 instance
     ( Applicative.Alternative r
     , Applicative.Alternative w
-    , Monoid s
     ) => Applicative.Alternative (Codec r w s i) where
     empty = Codec
         { decode = Applicative.empty
         , encode = const Applicative.empty
-        , schema = mempty
+        , schema = error "TODO"
         }
     cx <|> cy = Codec
         { decode = decode cx <|> decode cy
         , encode = \i -> encode cx i <|> encode cy i
-        , schema = schema cx <> schema cy
+        , schema = error "TODO"
         }
 
 map

--- a/source/library/Argo/Codec/List.hs
+++ b/source/library/Argo/Codec/List.hs
@@ -17,7 +17,7 @@ type List s e a
           a
 
 fromListCodec
-    :: (Permission.Permission -> s -> Schema.Schema)
+    :: (Permission.Permission -> s -> Identity.Identity Schema.Schema)
     -> Codec.Value [e]
     -> Permission.Permission
     -> List s e a

--- a/source/library/Argo/Codec/List.hs
+++ b/source/library/Argo/Codec/List.hs
@@ -20,7 +20,10 @@ type List s e a
 fromListCodec
     :: ( Permission.Permission
        -> s
-       -> Identity.Identity (Maybe Identifier.Identifier, Schema.Schema)
+       -> Trans.AccumT
+              ()
+              Identity.Identity
+              (Maybe Identifier.Identifier, Schema.Schema)
        )
     -> Codec.Value [e]
     -> Permission.Permission

--- a/source/library/Argo/Codec/List.hs
+++ b/source/library/Argo/Codec/List.hs
@@ -2,6 +2,7 @@ module Argo.Codec.List where
 
 import qualified Argo.Codec.Codec as Codec
 import qualified Argo.Codec.Value as Codec
+import qualified Argo.Schema.Identifier as Identifier
 import qualified Argo.Schema.Schema as Schema
 import qualified Argo.Type.Permission as Permission
 import qualified Argo.Vendor.Transformers as Trans
@@ -17,7 +18,10 @@ type List s e a
           a
 
 fromListCodec
-    :: (Permission.Permission -> s -> Identity.Identity Schema.Schema)
+    :: ( Permission.Permission
+       -> s
+       -> Identity.Identity (Maybe Identifier.Identifier, Schema.Schema)
+       )
     -> Codec.Value [e]
     -> Permission.Permission
     -> List s e a

--- a/source/library/Argo/Codec/List.hs
+++ b/source/library/Argo/Codec/List.hs
@@ -5,6 +5,7 @@ import qualified Argo.Codec.Value as Codec
 import qualified Argo.Schema.Identifier as Identifier
 import qualified Argo.Schema.Schema as Schema
 import qualified Argo.Type.Permission as Permission
+import qualified Argo.Vendor.Map as Map
 import qualified Argo.Vendor.Transformers as Trans
 import qualified Control.Monad as Monad
 import qualified Data.Functor.Identity as Identity
@@ -21,7 +22,7 @@ fromListCodec
     :: ( Permission.Permission
        -> s
        -> Trans.AccumT
-              ()
+              (Map.Map Identifier.Identifier Schema.Schema)
               Identity.Identity
               (Maybe Identifier.Identifier, Schema.Schema)
        )

--- a/source/library/Argo/Codec/Object.hs
+++ b/source/library/Argo/Codec/Object.hs
@@ -14,6 +14,7 @@ import qualified Argo.Json.Value as Value
 import qualified Argo.Schema.Identifier as Identifier
 import qualified Argo.Schema.Schema as Schema
 import qualified Argo.Type.Permission as Permission
+import qualified Argo.Vendor.Map as Map
 import qualified Argo.Vendor.Text as Text
 import qualified Argo.Vendor.Transformers as Trans
 import qualified Control.Monad as Monad
@@ -24,7 +25,7 @@ import qualified Data.Maybe as Maybe
 type Object a
     = Codec.List
           ( Trans.AccumT
-                ()
+                (Map.Map Identifier.Identifier Schema.Schema)
                 Identity.Identity
                 [ ( (Name.Name, Bool)
                   , (Maybe Identifier.Identifier, Schema.Schema)

--- a/source/library/Argo/Codec/Object.hs
+++ b/source/library/Argo/Codec/Object.hs
@@ -25,7 +25,10 @@ type Object a
     = Codec.List
           [ ( Name.Name
             , Bool
-            , Identity.Identity (Maybe Identifier.Identifier, Schema.Schema)
+            , Trans.AccumT
+                  ()
+                  Identity.Identity
+                  (Maybe Identifier.Identifier, Schema.Schema)
             )
           ]
           (Member.Member Value.Value)

--- a/source/library/Argo/Codec/Value.hs
+++ b/source/library/Argo/Codec/Value.hs
@@ -30,7 +30,7 @@ type Value a
     = Codec.Codec
           (Trans.ReaderT Value.Value (Trans.ExceptT String Identity.Identity))
           (Trans.MaybeT (Trans.StateT Value.Value Identity.Identity))
-          Schema.Schema
+          (Identity.Identity Schema.Schema)
           a
           a
 
@@ -45,7 +45,7 @@ arrayCodec = Codec.Codec
     , Codec.encode = \x -> do
         Trans.lift . Trans.put $ Value.Array x
         pure x
-    , Codec.schema = Schema.false
+    , Codec.schema = pure Schema.false
     }
 
 objectCodec :: Value (Object.Object Value.Value)
@@ -62,7 +62,7 @@ objectCodec = Codec.Codec
     , Codec.encode = \x -> do
         Trans.lift . Trans.put $ Value.Object x
         pure x
-    , Codec.schema = Schema.false
+    , Codec.schema = pure Schema.false
     }
 
 literalCodec :: Value.Value -> Value ()
@@ -77,7 +77,7 @@ literalCodec expected = Codec.Codec
             <> " but got "
             <> show actual
     , Codec.encode = const . Trans.lift $ Trans.put expected
-    , Codec.schema = Schema.fromValue . Value.Object $ Object.fromList
+    , Codec.schema = pure . Schema.fromValue . Value.Object $ Object.fromList
         [ Member.fromTuple
               (Name.fromString . String.fromText $ Text.pack "const", expected)
         ]

--- a/source/library/Argo/Codec/Value.hs
+++ b/source/library/Argo/Codec/Value.hs
@@ -31,7 +31,11 @@ type Value a
     = Codec.Codec
           (Trans.ReaderT Value.Value (Trans.ExceptT String Identity.Identity))
           (Trans.MaybeT (Trans.StateT Value.Value Identity.Identity))
-          (Identity.Identity (Maybe Identifier.Identifier, Schema.Schema))
+          ( Trans.AccumT
+                (){- TODO -}
+                Identity.Identity
+                (Maybe Identifier.Identifier, Schema.Schema)
+          )
           a
           a
 

--- a/source/library/Argo/Codec/Value.hs
+++ b/source/library/Argo/Codec/Value.hs
@@ -10,6 +10,7 @@ import qualified Argo.Json.String as String
 import qualified Argo.Json.Value as Value
 import qualified Argo.Schema.Identifier as Identifier
 import qualified Argo.Schema.Schema as Schema
+import qualified Argo.Vendor.Map as Map
 import qualified Argo.Vendor.Text as Text
 import qualified Argo.Vendor.Transformers as Trans
 import qualified Control.Monad as Monad
@@ -32,7 +33,7 @@ type Value a
           (Trans.ReaderT Value.Value (Trans.ExceptT String Identity.Identity))
           (Trans.MaybeT (Trans.StateT Value.Value Identity.Identity))
           ( Trans.AccumT
-                () -- TODO: map from identifiers to schemas
+                (Map.Map Identifier.Identifier Schema.Schema)
                 Identity.Identity
                 (Maybe Identifier.Identifier, Schema.Schema)
           )

--- a/source/library/Argo/Codec/Value.hs
+++ b/source/library/Argo/Codec/Value.hs
@@ -54,7 +54,7 @@ arrayCodec = Codec.Codec
     , Codec.encode = \x -> do
         Trans.lift . Trans.put $ Value.Array x
         pure x
-    , Codec.schema = pure (Nothing, Schema.false)
+    , Codec.schema = pure $ Schema.unidentified Schema.false
     }
 
 objectCodec :: Value (Object.Object Value.Value)
@@ -71,7 +71,7 @@ objectCodec = Codec.Codec
     , Codec.encode = \x -> do
         Trans.lift . Trans.put $ Value.Object x
         pure x
-    , Codec.schema = pure (Nothing, Schema.false)
+    , Codec.schema = pure $ Schema.unidentified Schema.false
     }
 
 literalCodec :: Value.Value -> Value ()
@@ -87,12 +87,16 @@ literalCodec expected = Codec.Codec
             <> show actual
     , Codec.encode = const . Trans.lift $ Trans.put expected
     , Codec.schema =
-        pure . (,) Nothing . Schema.fromValue . Value.Object $ Object.fromList
-            [ Member.fromTuple
-                  ( Name.fromString . String.fromText $ Text.pack "const"
-                  , expected
-                  )
-            ]
+        pure
+        . Schema.unidentified
+        . Schema.fromValue
+        . Value.Object
+        $ Object.fromList
+              [ Member.fromTuple
+                    ( Name.fromString . String.fromText $ Text.pack "const"
+                    , expected
+                    )
+              ]
     }
 
 identified :: forall a . Typeable.Typeable a => Value a -> Value a

--- a/source/library/Argo/Codec/Value.hs
+++ b/source/library/Argo/Codec/Value.hs
@@ -32,7 +32,7 @@ type Value a
           (Trans.ReaderT Value.Value (Trans.ExceptT String Identity.Identity))
           (Trans.MaybeT (Trans.StateT Value.Value Identity.Identity))
           ( Trans.AccumT
-                (){- TODO -}
+                () -- TODO: map from identifiers to schemas
                 Identity.Identity
                 (Maybe Identifier.Identifier, Schema.Schema)
           )

--- a/source/library/Argo/Codec/Value.hs
+++ b/source/library/Argo/Codec/Value.hs
@@ -135,7 +135,7 @@ ref e = case e of
               ( Name.fromString . String.fromText $ Text.pack "$ref"
               , Value.String
               . String.fromText
-              . mappend (Text.pack "#/$defs/")
+              . mappend (Text.pack "#/definitions/")
               $ Identifier.toText i
               )
         ]

--- a/source/library/Argo/Codec/Value.hs
+++ b/source/library/Argo/Codec/Value.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
 module Argo.Codec.Value where
 
 import qualified Argo.Codec.Codec as Codec
@@ -15,6 +17,7 @@ import qualified Argo.Vendor.Text as Text
 import qualified Argo.Vendor.Transformers as Trans
 import qualified Control.Monad as Monad
 import qualified Data.Functor.Identity as Identity
+import qualified Data.Typeable as Typeable
 
 decodeWith :: Value a -> Value.Value -> Either String a
 decodeWith c =
@@ -91,3 +94,10 @@ literalCodec expected = Codec.Codec
                   )
             ]
     }
+
+identified :: forall a . Typeable.Typeable a => Value a -> Value a
+identified c =
+    let
+        i = Identifier.fromText . Text.pack . show $ Typeable.typeRep
+            (Typeable.Proxy :: Typeable.Proxy a)
+    in c { Codec.schema = Schema.identified i . snd <$> Codec.schema c }

--- a/source/library/Argo/Schema/Identifier.hs
+++ b/source/library/Argo/Schema/Identifier.hs
@@ -7,11 +7,15 @@ module Argo.Schema.Identifier where
 import qualified Argo.Vendor.DeepSeq as DeepSeq
 import qualified Argo.Vendor.TemplateHaskell as TH
 import qualified Argo.Vendor.Text as Text
+import qualified Data.String as String
 import qualified GHC.Generics as Generics
 
 newtype Identifier
     = Identifier Text.Text
     deriving (Eq, Generics.Generic, TH.Lift, DeepSeq.NFData, Ord, Show)
+
+instance String.IsString Identifier where
+    fromString = fromText . String.fromString
 
 instance Semigroup Identifier where
     x <> y = fromText $ toText x <> toText y -- TODO: remove this

--- a/source/library/Argo/Schema/Identifier.hs
+++ b/source/library/Argo/Schema/Identifier.hs
@@ -1,0 +1,20 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveLift #-}
+
+module Argo.Schema.Identifier where
+
+import qualified Argo.Vendor.DeepSeq as DeepSeq
+import qualified Argo.Vendor.TemplateHaskell as TH
+import qualified Argo.Vendor.Text as Text
+import qualified GHC.Generics as Generics
+
+newtype Identifier
+    = Identifier Text.Text
+    deriving (Eq, Generics.Generic, TH.Lift, DeepSeq.NFData, Show)
+
+fromText :: Text.Text -> Identifier
+fromText = Identifier
+
+toText :: Identifier -> Text.Text
+toText (Identifier x) = x

--- a/source/library/Argo/Schema/Identifier.hs
+++ b/source/library/Argo/Schema/Identifier.hs
@@ -11,7 +11,7 @@ import qualified GHC.Generics as Generics
 
 newtype Identifier
     = Identifier Text.Text
-    deriving (Eq, Generics.Generic, TH.Lift, DeepSeq.NFData, Show)
+    deriving (Eq, Generics.Generic, TH.Lift, DeepSeq.NFData, Ord, Show)
 
 instance Semigroup Identifier where
     x <> y = fromText $ toText x <> toText y -- TODO: remove this

--- a/source/library/Argo/Schema/Identifier.hs
+++ b/source/library/Argo/Schema/Identifier.hs
@@ -13,6 +13,9 @@ newtype Identifier
     = Identifier Text.Text
     deriving (Eq, Generics.Generic, TH.Lift, DeepSeq.NFData, Show)
 
+instance Semigroup Identifier where
+    x <> y = fromText $ toText x <> toText y -- TODO: remove this
+
 fromText :: Text.Text -> Identifier
 fromText = Identifier
 

--- a/source/library/Argo/Schema/Schema.hs
+++ b/source/library/Argo/Schema/Schema.hs
@@ -11,6 +11,7 @@ import qualified Argo.Json.Name as Name
 import qualified Argo.Json.Object as Object
 import qualified Argo.Json.String as String
 import qualified Argo.Json.Value as Value
+import qualified Argo.Schema.Identifier as Identifier
 import qualified Argo.Vendor.DeepSeq as DeepSeq
 import qualified Argo.Vendor.TemplateHaskell as TH
 import qualified Argo.Vendor.Text as Text
@@ -44,3 +45,10 @@ false = fromValue . Value.Boolean $ Boolean.fromBool False
 
 true :: Schema
 true = fromValue . Value.Boolean $ Boolean.fromBool True
+
+unidentified :: Schema -> (Maybe Identifier.Identifier, Schema)
+unidentified s = (Nothing, s)
+
+identified
+    :: Identifier.Identifier -> Schema -> (Maybe Identifier.Identifier, Schema)
+identified i s = (Just i, s)

--- a/source/library/Argo/Vendor/Map.hs
+++ b/source/library/Argo/Vendor/Map.hs
@@ -1,7 +1,9 @@
 module Argo.Vendor.Map
     ( Map.Map
+    , Map.empty
     , Map.fromList
     , Map.mapKeys
+    , Map.member
     , Map.singleton
     , Map.toList
     ) where

--- a/source/library/Argo/Vendor/Map.hs
+++ b/source/library/Argo/Vendor/Map.hs
@@ -2,6 +2,7 @@ module Argo.Vendor.Map
     ( Map.Map
     , Map.fromList
     , Map.mapKeys
+    , Map.singleton
     , Map.toList
     ) where
 

--- a/source/library/Argo/Vendor/Transformers.hs
+++ b/source/library/Argo/Vendor/Transformers.hs
@@ -1,14 +1,18 @@
 module Argo.Vendor.Transformers
-    ( ExceptT.ExceptT
+    ( AccumT.AccumT
+    , ExceptT.ExceptT
     , MaybeT.MaybeT
     , ReaderT.ReaderT
     , StateT.StateT
     , WriterT.WriterT
+    , AccumT.add
     , ReaderT.ask
     , StateT.get
     , Trans.lift
     , ReaderT.local
+    , AccumT.look
     , StateT.put
+    , AccumT.runAccumT
     , ExceptT.runExceptT
     , MaybeT.runMaybeT
     , ReaderT.runReaderT
@@ -18,6 +22,7 @@ module Argo.Vendor.Transformers
     , ExceptT.throwE
     ) where
 
+import qualified Control.Monad.Trans.Accum as AccumT
 import qualified Control.Monad.Trans.Class as Trans
 import qualified Control.Monad.Trans.Except as ExceptT
 import qualified Control.Monad.Trans.Maybe as MaybeT

--- a/source/library/Argo/Vendor/Transformers.hs
+++ b/source/library/Argo/Vendor/Transformers.hs
@@ -1,31 +1,31 @@
 module Argo.Vendor.Transformers
-    ( AccumT.AccumT
-    , ExceptT.ExceptT
-    , MaybeT.MaybeT
-    , ReaderT.ReaderT
-    , StateT.StateT
-    , WriterT.WriterT
-    , AccumT.add
-    , ReaderT.ask
-    , StateT.get
+    ( Accum.AccumT
+    , Except.ExceptT
+    , Maybe.MaybeT
+    , Reader.ReaderT
+    , State.StateT
+    , Writer.WriterT
+    , Accum.add
+    , Reader.ask
+    , State.get
     , Trans.lift
-    , ReaderT.local
-    , AccumT.look
-    , StateT.put
-    , AccumT.runAccumT
-    , ExceptT.runExceptT
-    , MaybeT.runMaybeT
-    , ReaderT.runReaderT
-    , StateT.runStateT
-    , WriterT.runWriterT
-    , WriterT.tell
-    , ExceptT.throwE
+    , Reader.local
+    , Accum.look
+    , State.put
+    , Accum.runAccumT
+    , Except.runExceptT
+    , Maybe.runMaybeT
+    , Reader.runReaderT
+    , State.runStateT
+    , Writer.runWriterT
+    , Writer.tell
+    , Except.throwE
     ) where
 
-import qualified Control.Monad.Trans.Accum as AccumT
+import qualified Control.Monad.Trans.Accum as Accum
 import qualified Control.Monad.Trans.Class as Trans
-import qualified Control.Monad.Trans.Except as ExceptT
-import qualified Control.Monad.Trans.Maybe as MaybeT
-import qualified Control.Monad.Trans.Reader as ReaderT
-import qualified Control.Monad.Trans.State as StateT
-import qualified Control.Monad.Trans.Writer as WriterT
+import qualified Control.Monad.Trans.Except as Except
+import qualified Control.Monad.Trans.Maybe as Maybe
+import qualified Control.Monad.Trans.Reader as Reader
+import qualified Control.Monad.Trans.State as State
+import qualified Control.Monad.Trans.Writer as Writer

--- a/source/test-suite/Main.hs
+++ b/source/test-suite/Main.hs
@@ -1208,7 +1208,7 @@ hush = either (const Nothing) Just
 schemafy
     :: Schema.Schema
     -> Accum.AccumT
-           ()
+           (Map.Map Identifier.Identifier Schema.Schema)
            Identity.Identity
            (Maybe Identifier.Identifier, Schema.Schema)
 schemafy = pure . (,) Nothing

--- a/source/test-suite/Main.hs
+++ b/source/test-suite/Main.hs
@@ -737,38 +737,38 @@ main = Tasty.defaultMain $ Tasty.testGroup
     , Tasty.testGroup
         "Schema"
         [ Tasty.testCase "value" $ do
-            let expected = schemafy (Just "value") [Argo.schema| true |]
+            let expected = schemafy (Just "Value") [Argo.schema| true |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Argo.Value)
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "null" $ do
             let expected =
-                    schemafy (Just "null") [Argo.schema| { "type": "null" } |]
+                    schemafy (Just "Null") [Argo.schema| { "type": "null" } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Null.Null)
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "boolean" $ do
             let expected = schemafy
-                    (Just "boolean")
+                    (Just "Boolean")
                     [Argo.schema| { "type": "boolean" } |]
                 actual =
                     Codec.schema (Argo.codec :: Codec.Value Boolean.Boolean)
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "number" $ do
             let expected = schemafy
-                    (Just "number")
+                    (Just "Number")
                     [Argo.schema| { "type": "number" } |]
                 actual =
                     Codec.schema (Argo.codec :: Codec.Value Number.Number)
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "string" $ do
             let expected = schemafy
-                    (Just "string")
+                    (Just "String")
                     [Argo.schema| { "type": "string" } |]
                 actual =
                     Codec.schema (Argo.codec :: Codec.Value String.String)
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "array boolean" $ do
             let expected = schemafy
-                    (Just "array-boolean")
+                    (Just "Array Boolean")
                     [Argo.schema| { "type": "array", "items": { "type": "boolean" } } |]
                 actual =
                     Codec.schema
@@ -778,7 +778,7 @@ main = Tasty.defaultMain $ Tasty.testGroup
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "object boolean" $ do
             let expected = schemafy
-                    (Just "object-boolean")
+                    (Just "Object Boolean")
                     [Argo.schema| { "type": "object", "additionalProperties": { "type": "boolean" } } |]
                 actual =
                     Codec.schema
@@ -788,14 +788,14 @@ main = Tasty.defaultMain $ Tasty.testGroup
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "maybe boolean" $ do
             let expected = schemafy
-                    (Just "booleannull")
+                    (Just "Maybe Boolean")
                     [Argo.schema| { "oneOf": [ { "type": "boolean" }, { "type": "null" } ] } |]
                 actual = Codec.schema
                     (Argo.codec :: Codec.Value (Maybe Boolean.Boolean))
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "either boolean number" $ do
             let expected = schemafy
-                    Nothing
+                    (Just "Either Boolean Number")
                     [Argo.schema| { "oneOf": [ { "type": "object", "properties": { "type": { "const": "Left" }, "value": { "type": "boolean" } }, "required": [ "type", "value" ], "additionalProperties": false }, { "type": "object", "properties": { "type": { "const": "Right" }, "value": { "type": "number" } }, "required": [ "type", "value" ], "additionalProperties": false } ] } |]
                 actual =
                     Codec.schema
@@ -805,139 +805,172 @@ main = Tasty.defaultMain $ Tasty.testGroup
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "()" $ do
             let expected = schemafy
-                    Nothing
+                    (Just "()")
                     [Argo.schema| { "type": "array", "items": [], "additionalItems": false } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value ())
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "2-tuple" $ do
             let expected = schemafy
-                    Nothing
+                    (Just "(Value,Null)")
                     [Argo.schema| { "type": "array", "items":
-                        [ { "type": "boolean" }
-                        , { "type": "boolean" }
+                        [ true
+                        , { "type": "null" }
                         ], "additionalItems": false } |]
-                actual = Codec.schema (Argo.codec :: Codec.Value (Bool, Bool))
+                actual = Codec.schema
+                    (Argo.codec :: Codec.Value (Argo.Value, Null.Null))
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "3-tuple" $ do
             let expected = schemafy
-                    Nothing
+                    (Just "(Value,Null,Boolean)")
                     [Argo.schema| { "type": "array", "items":
-                        [ { "type": "boolean" }
-                        , { "type": "boolean" }
-                        , { "type": "boolean" }
-                        ], "additionalItems": false } |]
-                actual =
-                    Codec.schema (Argo.codec :: Codec.Value (Bool, Bool, Bool))
-            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
-        , Tasty.testCase "4-tuple" $ do
-            let expected = schemafy
-                    Nothing
-                    [Argo.schema| { "type": "array", "items":
-                        [ { "type": "boolean" }
-                        , { "type": "boolean" }
-                        , { "type": "boolean" }
-                        , { "type": "boolean" }
-                        ], "additionalItems": false } |]
-                actual = Codec.schema
-                    (Argo.codec :: Codec.Value (Bool, Bool, Bool, Bool))
-            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
-        , Tasty.testCase "5-tuple" $ do
-            let expected = schemafy
-                    Nothing
-                    [Argo.schema| { "type": "array", "items":
-                        [ { "type": "boolean" }
-                        , { "type": "boolean" }
-                        , { "type": "boolean" }
-                        , { "type": "boolean" }
-                        , { "type": "boolean" }
-                        ], "additionalItems": false } |]
-                actual =
-                    Codec.schema
-                        (Argo.codec :: Codec.Value
-                              (Bool, Bool, Bool, Bool, Bool)
-                        )
-            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
-        , Tasty.testCase "6-tuple" $ do
-            let expected = schemafy
-                    Nothing
-                    [Argo.schema| { "type": "array", "items":
-                        [ { "type": "boolean" }
-                        , { "type": "boolean" }
-                        , { "type": "boolean" }
-                        , { "type": "boolean" }
-                        , { "type": "boolean" }
-                        , { "type": "boolean" }
-                        ], "additionalItems": false } |]
-                actual =
-                    Codec.schema
-                        (Argo.codec :: Codec.Value
-                              (Bool, Bool, Bool, Bool, Bool, Bool)
-                        )
-            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
-        , Tasty.testCase "7-tuple" $ do
-            let expected = schemafy
-                    Nothing
-                    [Argo.schema| { "type": "array", "items":
-                        [ { "type": "boolean" }
-                        , { "type": "boolean" }
-                        , { "type": "boolean" }
-                        , { "type": "boolean" }
-                        , { "type": "boolean" }
-                        , { "type": "boolean" }
+                        [ true
+                        , { "type": "null" }
                         , { "type": "boolean" }
                         ], "additionalItems": false } |]
                 actual = Codec.schema
                     (Argo.codec :: Codec.Value
-                          (Bool, Bool, Bool, Bool, Bool, Bool, Bool)
+                          (Argo.Value, Null.Null, Boolean.Boolean)
+                    )
+            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
+        , Tasty.testCase "4-tuple" $ do
+            let expected = schemafy
+                    (Just "(Value,Null,Boolean,Number)")
+                    [Argo.schema| { "type": "array", "items":
+                        [ true
+                        , { "type": "null" }
+                        , { "type": "boolean" }
+                        , { "type": "number" }
+                        ], "additionalItems": false } |]
+                actual = Codec.schema
+                    (Argo.codec :: Codec.Value
+                          ( Argo.Value
+                          , Null.Null
+                          , Boolean.Boolean
+                          , Number.Number
+                          )
+                    )
+            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
+        , Tasty.testCase "5-tuple" $ do
+            let expected = schemafy
+                    (Just "(Value,Null,Boolean,Number,Integer)")
+                    [Argo.schema| { "type": "array", "items":
+                        [ true
+                        , { "type": "null" }
+                        , { "type": "boolean" }
+                        , { "type": "number" }
+                        , { "type": "integer" }
+                        ], "additionalItems": false } |]
+                actual = Codec.schema
+                    (Argo.codec :: Codec.Value
+                          ( Argo.Value
+                          , Null.Null
+                          , Boolean.Boolean
+                          , Number.Number
+                          , Integer
+                          )
+                    )
+            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
+        , Tasty.testCase "6-tuple" $ do
+            let expected = schemafy
+                    (Just "(Value,Null,Boolean,Number,Integer,String)")
+                    [Argo.schema| { "type": "array", "items":
+                        [ true
+                        , { "type": "null" }
+                        , { "type": "boolean" }
+                        , { "type": "number" }
+                        , { "type": "integer" }
+                        , { "type": "string" }
+                        ], "additionalItems": false } |]
+                actual = Codec.schema
+                    (Argo.codec :: Codec.Value
+                          ( Argo.Value
+                          , Null.Null
+                          , Boolean.Boolean
+                          , Number.Number
+                          , Integer
+                          , String.String
+                          )
+                    )
+            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
+        , Tasty.testCase "7-tuple" $ do
+            let expected = schemafy
+                    (Just "(Value,Null,Boolean,Number,Integer,String,())")
+                    [Argo.schema| { "type": "array", "items":
+                        [ true
+                        , { "type": "null" }
+                        , { "type": "boolean" }
+                        , { "type": "number" }
+                        , { "type": "integer" }
+                        , { "type": "string" }
+                        , { "type": "array", "items": [], "additionalItems": false }
+                        ], "additionalItems": false } |]
+                actual = Codec.schema
+                    (Argo.codec :: Codec.Value
+                          ( Argo.Value
+                          , Null.Null
+                          , Boolean.Boolean
+                          , Number.Number
+                          , Integer
+                          , String.String
+                          , ()
+                          )
                     )
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "8-tuple" $ do
             let expected = schemafy
-                    Nothing
+                    (Just "(Value,Null,Boolean,Number,Integer,String,(),Char)")
                     [Argo.schema| { "type": "array", "items":
-                        [ { "type": "boolean" }
+                        [ true
+                        , { "type": "null" }
                         , { "type": "boolean" }
-                        , { "type": "boolean" }
-                        , { "type": "boolean" }
-                        , { "type": "boolean" }
-                        , { "type": "boolean" }
-                        , { "type": "boolean" }
-                        , { "type": "boolean" }
+                        , { "type": "number" }
+                        , { "type": "integer" }
+                        , { "type": "string" }
+                        , { "type": "array", "items": [], "additionalItems": false }
+                        , { "type": "string", "minLength": 1, "maxLength": 1 }
                         ], "additionalItems": false } |]
                 actual = Codec.schema
                     (Argo.codec :: Codec.Value
-                          (Bool, Bool, Bool, Bool, Bool, Bool, Bool, Bool)
+                          ( Argo.Value
+                          , Null.Null
+                          , Boolean.Boolean
+                          , Number.Number
+                          , Integer
+                          , String.String
+                          , ()
+                          , Char
+                          )
                     )
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "bool" $ do
             let expected = schemafy
-                    (Just "boolean")
+                    (Just "Bool")
                     [Argo.schema| { "type": "boolean" } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Bool)
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "decimal" $ do
             let expected = schemafy
-                    (Just "number")
+                    (Just "Decimal")
                     [Argo.schema| { "type": "number" } |]
                 actual =
                     Codec.schema (Argo.codec :: Codec.Value Decimal.Decimal)
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "text" $ do
             let expected = schemafy
-                    (Just "string")
+                    (Just "Text")
                     [Argo.schema| { "type": "string" } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Text.Text)
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "list boolean" $ do
             let expected = schemafy
-                    (Just "array-boolean")
+                    (Just "[Boolean]")
                     [Argo.schema| { "type": "array", "items": { "type": "boolean" } } |]
                 actual =
                     Codec.schema (Argo.codec :: Codec.Value [Boolean.Boolean])
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "map name boolean" $ do
             let expected = schemafy
-                    (Just "object-boolean")
+                    (Just "Map Name Boolean")
                     [Argo.schema| { "type": "object", "additionalProperties": { "type": "boolean" } } |]
                 actual =
                     Codec.schema
@@ -947,7 +980,7 @@ main = Tasty.defaultMain $ Tasty.testGroup
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "map (argo) string boolean" $ do
             let expected = schemafy
-                    (Just "object-boolean")
+                    (Just "Map String Boolean")
                     [Argo.schema| { "type": "object", "additionalProperties": { "type": "boolean" } } |]
                 actual = Codec.schema
                     (Argo.codec :: Codec.Value
@@ -956,7 +989,7 @@ main = Tasty.defaultMain $ Tasty.testGroup
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "map (strict) text boolean" $ do
             let expected = schemafy
-                    (Just "object-boolean")
+                    (Just "Map Text Boolean")
                     [Argo.schema| { "type": "object", "additionalProperties": { "type": "boolean" } } |]
                 actual =
                     Codec.schema
@@ -966,7 +999,7 @@ main = Tasty.defaultMain $ Tasty.testGroup
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "map (lazy) text boolean" $ do
             let expected = schemafy
-                    (Just "object-boolean")
+                    (Just "Map Text Boolean")
                     [Argo.schema| { "type": "object", "additionalProperties": { "type": "boolean" } } |]
                 actual = Codec.schema
                     (Argo.codec :: Codec.Value
@@ -975,7 +1008,7 @@ main = Tasty.defaultMain $ Tasty.testGroup
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "map (base) string boolean" $ do
             let expected = schemafy
-                    (Just "object-boolean")
+                    (Just "Map [Char] Boolean")
                     [Argo.schema| { "type": "object", "additionalProperties": { "type": "boolean" } } |]
                 actual =
                     Codec.schema
@@ -985,129 +1018,129 @@ main = Tasty.defaultMain $ Tasty.testGroup
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "string" $ do
             let expected = schemafy
-                    (Just "string")
+                    (Just "[Char]")
                     [Argo.schema| { "type": "string" } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value String)
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "char" $ do
             let expected = schemafy
-                    (Just "char")
+                    (Just "Char")
                     [Argo.schema| { "type": "string", "minLength": 1, "maxLength": 1 } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Char)
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "lazy text" $ do
             let expected = schemafy
-                    (Just "string")
+                    (Just "Text")
                     [Argo.schema| { "type": "string" } |]
                 actual =
                     Codec.schema (Argo.codec :: Codec.Value LazyText.Text)
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
-        , Tasty.testCase "list boolean" $ do
+        , Tasty.testCase "non-empty boolean" $ do
             let expected = schemafy
-                    (Just "non-empty-boolean")
+                    (Just "NonEmpty Boolean")
                     [Argo.schema| { "type": "array", "items": { "type": "boolean" }, "minItems": 1 } |]
                 actual = Codec.schema
                     (Argo.codec :: Codec.Value (NonEmpty Boolean.Boolean))
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "integer" $ do
             let expected = schemafy
-                    (Just "integer")
+                    (Just "Integer")
                     [Argo.schema| { "type": "integer" } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Integer)
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "int" $ do
             let expected = schemafy
-                    (Just "int")
+                    (Just "Int")
                     [Argo.schema| { "type": "integer", "minimum": -9223372036854775808, "maximum": 9223372036854775807 } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Int)
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "int8" $ do
             let expected = schemafy
-                    (Just "int8")
+                    (Just "Int8")
                     [Argo.schema| { "type": "integer", "minimum": -128, "maximum": 127 } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Int.Int8)
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "int16" $ do
             let expected = schemafy
-                    (Just "int16")
+                    (Just "Int16")
                     [Argo.schema| { "type": "integer", "minimum": -32768, "maximum": 32767 } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Int.Int16)
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "int32" $ do
             let expected = schemafy
-                    (Just "int32")
+                    (Just "Int32")
                     [Argo.schema| { "type": "integer", "minimum": -2147483648, "maximum": 2147483647 } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Int.Int32)
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "int64" $ do
             let expected = schemafy
-                    (Just "int64")
+                    (Just "Int64")
                     [Argo.schema| { "type": "integer", "minimum": -9223372036854775808, "maximum": 9223372036854775807 } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Int.Int64)
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "natural" $ do
             let expected = schemafy
-                    (Just "natural")
+                    (Just "Natural")
                     [Argo.schema| { "type": "integer", "minimum": 0 } |]
                 actual =
                     Codec.schema (Argo.codec :: Codec.Value Natural.Natural)
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "word" $ do
             let expected = schemafy
-                    (Just "word")
+                    (Just "Word")
                     [Argo.schema| { "type": "integer", "minimum": 0, "maximum": 18446744073709551615 } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Word)
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "word8" $ do
             let expected = schemafy
-                    (Just "word8")
+                    (Just "Word8")
                     [Argo.schema| { "type": "integer", "minimum": 0, "maximum": 255 } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Word.Word8)
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "word16" $ do
             let expected = schemafy
-                    (Just "word16")
+                    (Just "Word16")
                     [Argo.schema| { "type": "integer", "minimum": 0, "maximum": 65535 } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Word.Word16)
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "word32" $ do
             let expected = schemafy
-                    (Just "word32")
+                    (Just "Word32")
                     [Argo.schema| { "type": "integer", "minimum": 0, "maximum": 4294967295 } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Word.Word32)
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "word64" $ do
             let expected = schemafy
-                    (Just "word64")
+                    (Just "Word64")
                     [Argo.schema| { "type": "integer", "minimum": 0, "maximum": 18446744073709551615 } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Word.Word64)
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "float" $ do
             let expected = schemafy
-                    (Just "number")
+                    (Just "Float")
                     [Argo.schema| { "type": "number" } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Float)
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "double" $ do
             let expected = schemafy
-                    (Just "number")
+                    (Just "Double")
                     [Argo.schema| { "type": "number" } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Double)
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "pointer" $ do
             let expected = schemafy
-                    (Just "string")
+                    (Just "Pointer")
                     [Argo.schema| { "type": "string" } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Argo.Pointer)
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "schema" $ do
-            let expected = schemafy (Just "value") [Argo.schema| true |]
+            let expected = schemafy (Just "Schema") [Argo.schema| true |]
                 actual =
                     Codec.schema (Argo.codec :: Codec.Value Schema.Schema)
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "record" $ do
             let expected = schemafy
-                    Nothing
+                    Nothing  -- TODO
                     [Argo.schema| { "type": "object", "properties": { "bool": { "type": "boolean" }, "text": { "type": "string" } }, "required": [ "bool" ], "additionalProperties": true } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Record)
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
@@ -1117,7 +1150,7 @@ main = Tasty.defaultMain $ Tasty.testGroup
           in
               [ Tasty.testCase "schema" $ do
                   let expected = schemafy
-                          Nothing
+                          Nothing  -- TODO
                           [Argo.schema|
                             {
                                 "type": "object",

--- a/source/test-suite/Main.hs
+++ b/source/test-suite/Main.hs
@@ -737,32 +737,39 @@ main = Tasty.defaultMain $ Tasty.testGroup
     , Tasty.testGroup
         "Schema"
         [ Tasty.testCase "value" $ do
-            let expected = schemafy [Argo.schema| true |]
+            let expected = schemafy (Just "value") [Argo.schema| true |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Argo.Value)
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "null" $ do
-            let expected = schemafy [Argo.schema| { "type": "null" } |]
+            let expected =
+                    schemafy (Just "null") [Argo.schema| { "type": "null" } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Null.Null)
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "boolean" $ do
-            let expected = schemafy [Argo.schema| { "type": "boolean" } |]
+            let expected = schemafy
+                    (Just "boolean")
+                    [Argo.schema| { "type": "boolean" } |]
                 actual =
                     Codec.schema (Argo.codec :: Codec.Value Boolean.Boolean)
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "number" $ do
-            let expected = schemafy [Argo.schema| { "type": "number" } |]
+            let expected = schemafy
+                    (Just "number")
+                    [Argo.schema| { "type": "number" } |]
                 actual =
                     Codec.schema (Argo.codec :: Codec.Value Number.Number)
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "string" $ do
-            let expected = schemafy [Argo.schema| { "type": "string" } |]
+            let expected = schemafy
+                    (Just "string")
+                    [Argo.schema| { "type": "string" } |]
                 actual =
                     Codec.schema (Argo.codec :: Codec.Value String.String)
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "array boolean" $ do
-            let expected =
-                    schemafy
-                        [Argo.schema| { "type": "array", "items": { "type": "boolean" } } |]
+            let expected = schemafy
+                    (Just "array-boolean")
+                    [Argo.schema| { "type": "array", "items": { "type": "boolean" } } |]
                 actual =
                     Codec.schema
                         (Argo.codec :: Codec.Value
@@ -770,9 +777,9 @@ main = Tasty.defaultMain $ Tasty.testGroup
                         )
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "object boolean" $ do
-            let expected =
-                    schemafy
-                        [Argo.schema| { "type": "object", "additionalProperties": { "type": "boolean" } } |]
+            let expected = schemafy
+                    (Just "object-boolean")
+                    [Argo.schema| { "type": "object", "additionalProperties": { "type": "boolean" } } |]
                 actual =
                     Codec.schema
                         (Argo.codec :: Codec.Value
@@ -780,16 +787,16 @@ main = Tasty.defaultMain $ Tasty.testGroup
                         )
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "maybe boolean" $ do
-            let expected =
-                    schemafy
-                        [Argo.schema| { "oneOf": [ { "type": "boolean" }, { "type": "null" } ] } |]
+            let expected = schemafy
+                    (Just "booleannull")
+                    [Argo.schema| { "oneOf": [ { "type": "boolean" }, { "type": "null" } ] } |]
                 actual = Codec.schema
                     (Argo.codec :: Codec.Value (Maybe Boolean.Boolean))
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "either boolean number" $ do
-            let expected =
-                    schemafy
-                        [Argo.schema| { "oneOf": [ { "type": "object", "properties": { "type": { "const": "Left" }, "value": { "type": "boolean" } }, "required": [ "type", "value" ], "additionalProperties": false }, { "type": "object", "properties": { "type": { "const": "Right" }, "value": { "type": "number" } }, "required": [ "type", "value" ], "additionalProperties": false } ] } |]
+            let expected = schemafy
+                    Nothing
+                    [Argo.schema| { "oneOf": [ { "type": "object", "properties": { "type": { "const": "Left" }, "value": { "type": "boolean" } }, "required": [ "type", "value" ], "additionalProperties": false }, { "type": "object", "properties": { "type": { "const": "Right" }, "value": { "type": "number" } }, "required": [ "type", "value" ], "additionalProperties": false } ] } |]
                 actual =
                     Codec.schema
                         (Argo.codec :: Codec.Value
@@ -797,40 +804,47 @@ main = Tasty.defaultMain $ Tasty.testGroup
                         )
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "()" $ do
-            let expected =
-                    schemafy
-                        [Argo.schema| { "type": "array", "items": [], "additionalItems": false } |]
+            let expected = schemafy
+                    Nothing
+                    [Argo.schema| { "type": "array", "items": [], "additionalItems": false } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value ())
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "2-tuple" $ do
-            let expected = schemafy [Argo.schema| { "type": "array", "items":
+            let expected = schemafy
+                    Nothing
+                    [Argo.schema| { "type": "array", "items":
                         [ { "type": "boolean" }
                         , { "type": "boolean" }
                         ], "additionalItems": false } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value (Bool, Bool))
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "3-tuple" $ do
-            let expected = schemafy [Argo.schema| { "type": "array", "items":
+            let expected = schemafy
+                    Nothing
+                    [Argo.schema| { "type": "array", "items":
                         [ { "type": "boolean" }
-                        , { "type": "boolean" }
-                        , { "type": "boolean" }
-                        ], "additionalItems": false } |]
-                actual = Codec.schema
-                    (Argo.codec :: Codec.Value (Bool, Bool, Bool))
-            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
-        , Tasty.testCase "4-tuple" $ do
-            let expected = schemafy [Argo.schema| { "type": "array", "items":
-                        [ { "type": "boolean" }
-                        , { "type": "boolean" }
                         , { "type": "boolean" }
                         , { "type": "boolean" }
                         ], "additionalItems": false } |]
                 actual =
-                    Codec.schema
-                        (Argo.codec :: Codec.Value (Bool, Bool, Bool, Bool))
+                    Codec.schema (Argo.codec :: Codec.Value (Bool, Bool, Bool))
+            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
+        , Tasty.testCase "4-tuple" $ do
+            let expected = schemafy
+                    Nothing
+                    [Argo.schema| { "type": "array", "items":
+                        [ { "type": "boolean" }
+                        , { "type": "boolean" }
+                        , { "type": "boolean" }
+                        , { "type": "boolean" }
+                        ], "additionalItems": false } |]
+                actual = Codec.schema
+                    (Argo.codec :: Codec.Value (Bool, Bool, Bool, Bool))
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "5-tuple" $ do
-            let expected = schemafy [Argo.schema| { "type": "array", "items":
+            let expected = schemafy
+                    Nothing
+                    [Argo.schema| { "type": "array", "items":
                         [ { "type": "boolean" }
                         , { "type": "boolean" }
                         , { "type": "boolean" }
@@ -844,7 +858,9 @@ main = Tasty.defaultMain $ Tasty.testGroup
                         )
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "6-tuple" $ do
-            let expected = schemafy [Argo.schema| { "type": "array", "items":
+            let expected = schemafy
+                    Nothing
+                    [Argo.schema| { "type": "array", "items":
                         [ { "type": "boolean" }
                         , { "type": "boolean" }
                         , { "type": "boolean" }
@@ -859,7 +875,9 @@ main = Tasty.defaultMain $ Tasty.testGroup
                         )
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "7-tuple" $ do
-            let expected = schemafy [Argo.schema| { "type": "array", "items":
+            let expected = schemafy
+                    Nothing
+                    [Argo.schema| { "type": "array", "items":
                         [ { "type": "boolean" }
                         , { "type": "boolean" }
                         , { "type": "boolean" }
@@ -874,7 +892,9 @@ main = Tasty.defaultMain $ Tasty.testGroup
                     )
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "8-tuple" $ do
-            let expected = schemafy [Argo.schema| { "type": "array", "items":
+            let expected = schemafy
+                    Nothing
+                    [Argo.schema| { "type": "array", "items":
                         [ { "type": "boolean" }
                         , { "type": "boolean" }
                         , { "type": "boolean" }
@@ -890,29 +910,35 @@ main = Tasty.defaultMain $ Tasty.testGroup
                     )
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "bool" $ do
-            let expected = schemafy [Argo.schema| { "type": "boolean" } |]
+            let expected = schemafy
+                    (Just "boolean")
+                    [Argo.schema| { "type": "boolean" } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Bool)
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "decimal" $ do
-            let expected = schemafy [Argo.schema| { "type": "number" } |]
+            let expected = schemafy
+                    (Just "number")
+                    [Argo.schema| { "type": "number" } |]
                 actual =
                     Codec.schema (Argo.codec :: Codec.Value Decimal.Decimal)
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "text" $ do
-            let expected = schemafy [Argo.schema| { "type": "string" } |]
+            let expected = schemafy
+                    (Just "string")
+                    [Argo.schema| { "type": "string" } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Text.Text)
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "list boolean" $ do
-            let expected =
-                    schemafy
-                        [Argo.schema| { "type": "array", "items": { "type": "boolean" } } |]
+            let expected = schemafy
+                    (Just "array-boolean")
+                    [Argo.schema| { "type": "array", "items": { "type": "boolean" } } |]
                 actual =
                     Codec.schema (Argo.codec :: Codec.Value [Boolean.Boolean])
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "map name boolean" $ do
-            let expected =
-                    schemafy
-                        [Argo.schema| { "type": "object", "additionalProperties": { "type": "boolean" } } |]
+            let expected = schemafy
+                    (Just "object-boolean")
+                    [Argo.schema| { "type": "object", "additionalProperties": { "type": "boolean" } } |]
                 actual =
                     Codec.schema
                         (Argo.codec :: Codec.Value
@@ -920,18 +946,18 @@ main = Tasty.defaultMain $ Tasty.testGroup
                         )
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "map (argo) string boolean" $ do
-            let expected =
-                    schemafy
-                        [Argo.schema| { "type": "object", "additionalProperties": { "type": "boolean" } } |]
+            let expected = schemafy
+                    (Just "object-boolean")
+                    [Argo.schema| { "type": "object", "additionalProperties": { "type": "boolean" } } |]
                 actual = Codec.schema
                     (Argo.codec :: Codec.Value
                           (Map.Map String.String Boolean.Boolean)
                     )
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "map (strict) text boolean" $ do
-            let expected =
-                    schemafy
-                        [Argo.schema| { "type": "object", "additionalProperties": { "type": "boolean" } } |]
+            let expected = schemafy
+                    (Just "object-boolean")
+                    [Argo.schema| { "type": "object", "additionalProperties": { "type": "boolean" } } |]
                 actual =
                     Codec.schema
                         (Argo.codec :: Codec.Value
@@ -939,18 +965,18 @@ main = Tasty.defaultMain $ Tasty.testGroup
                         )
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "map (lazy) text boolean" $ do
-            let expected =
-                    schemafy
-                        [Argo.schema| { "type": "object", "additionalProperties": { "type": "boolean" } } |]
+            let expected = schemafy
+                    (Just "object-boolean")
+                    [Argo.schema| { "type": "object", "additionalProperties": { "type": "boolean" } } |]
                 actual = Codec.schema
                     (Argo.codec :: Codec.Value
                           (Map.Map LazyText.Text Boolean.Boolean)
                     )
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "map (base) string boolean" $ do
-            let expected =
-                    schemafy
-                        [Argo.schema| { "type": "object", "additionalProperties": { "type": "boolean" } } |]
+            let expected = schemafy
+                    (Just "object-boolean")
+                    [Argo.schema| { "type": "object", "additionalProperties": { "type": "boolean" } } |]
                 actual =
                     Codec.schema
                         (Argo.codec :: Codec.Value
@@ -958,118 +984,131 @@ main = Tasty.defaultMain $ Tasty.testGroup
                         )
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "string" $ do
-            let expected = schemafy [Argo.schema| { "type": "string" } |]
+            let expected = schemafy
+                    (Just "string")
+                    [Argo.schema| { "type": "string" } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value String)
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "char" $ do
-            let expected =
-                    schemafy
-                        [Argo.schema| { "type": "string", "minLength": 1, "maxLength": 1 } |]
+            let expected = schemafy
+                    (Just "char")
+                    [Argo.schema| { "type": "string", "minLength": 1, "maxLength": 1 } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Char)
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "lazy text" $ do
-            let expected = schemafy [Argo.schema| { "type": "string" } |]
+            let expected = schemafy
+                    (Just "string")
+                    [Argo.schema| { "type": "string" } |]
                 actual =
                     Codec.schema (Argo.codec :: Codec.Value LazyText.Text)
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "list boolean" $ do
-            let expected =
-                    schemafy
-                        [Argo.schema| { "type": "array", "items": { "type": "boolean" }, "minItems": 1 } |]
+            let expected = schemafy
+                    (Just "non-empty-boolean")
+                    [Argo.schema| { "type": "array", "items": { "type": "boolean" }, "minItems": 1 } |]
                 actual = Codec.schema
                     (Argo.codec :: Codec.Value (NonEmpty Boolean.Boolean))
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "integer" $ do
-            let expected = schemafy [Argo.schema| { "type": "integer" } |]
+            let expected = schemafy
+                    (Just "integer")
+                    [Argo.schema| { "type": "integer" } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Integer)
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "int" $ do
-            let expected =
-                    schemafy
-                        [Argo.schema| { "type": "integer", "minimum": -9223372036854775808, "maximum": 9223372036854775807 } |]
+            let expected = schemafy
+                    (Just "int")
+                    [Argo.schema| { "type": "integer", "minimum": -9223372036854775808, "maximum": 9223372036854775807 } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Int)
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "int8" $ do
-            let expected =
-                    schemafy
-                        [Argo.schema| { "type": "integer", "minimum": -128, "maximum": 127 } |]
+            let expected = schemafy
+                    (Just "int8")
+                    [Argo.schema| { "type": "integer", "minimum": -128, "maximum": 127 } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Int.Int8)
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "int16" $ do
-            let expected =
-                    schemafy
-                        [Argo.schema| { "type": "integer", "minimum": -32768, "maximum": 32767 } |]
+            let expected = schemafy
+                    (Just "int16")
+                    [Argo.schema| { "type": "integer", "minimum": -32768, "maximum": 32767 } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Int.Int16)
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "int32" $ do
-            let expected =
-                    schemafy
-                        [Argo.schema| { "type": "integer", "minimum": -2147483648, "maximum": 2147483647 } |]
+            let expected = schemafy
+                    (Just "int32")
+                    [Argo.schema| { "type": "integer", "minimum": -2147483648, "maximum": 2147483647 } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Int.Int32)
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "int64" $ do
-            let expected =
-                    schemafy
-                        [Argo.schema| { "type": "integer", "minimum": -9223372036854775808, "maximum": 9223372036854775807 } |]
+            let expected = schemafy
+                    (Just "int64")
+                    [Argo.schema| { "type": "integer", "minimum": -9223372036854775808, "maximum": 9223372036854775807 } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Int.Int64)
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "natural" $ do
             let expected = schemafy
+                    (Just "natural")
                     [Argo.schema| { "type": "integer", "minimum": 0 } |]
                 actual =
                     Codec.schema (Argo.codec :: Codec.Value Natural.Natural)
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "word" $ do
-            let expected =
-                    schemafy
-                        [Argo.schema| { "type": "integer", "minimum": 0, "maximum": 18446744073709551615 } |]
+            let expected = schemafy
+                    (Just "word")
+                    [Argo.schema| { "type": "integer", "minimum": 0, "maximum": 18446744073709551615 } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Word)
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "word8" $ do
-            let expected =
-                    schemafy
-                        [Argo.schema| { "type": "integer", "minimum": 0, "maximum": 255 } |]
+            let expected = schemafy
+                    (Just "word8")
+                    [Argo.schema| { "type": "integer", "minimum": 0, "maximum": 255 } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Word.Word8)
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "word16" $ do
-            let expected =
-                    schemafy
-                        [Argo.schema| { "type": "integer", "minimum": 0, "maximum": 65535 } |]
+            let expected = schemafy
+                    (Just "word16")
+                    [Argo.schema| { "type": "integer", "minimum": 0, "maximum": 65535 } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Word.Word16)
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "word32" $ do
-            let expected =
-                    schemafy
-                        [Argo.schema| { "type": "integer", "minimum": 0, "maximum": 4294967295 } |]
+            let expected = schemafy
+                    (Just "word32")
+                    [Argo.schema| { "type": "integer", "minimum": 0, "maximum": 4294967295 } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Word.Word32)
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "word64" $ do
-            let expected =
-                    schemafy
-                        [Argo.schema| { "type": "integer", "minimum": 0, "maximum": 18446744073709551615 } |]
+            let expected = schemafy
+                    (Just "word64")
+                    [Argo.schema| { "type": "integer", "minimum": 0, "maximum": 18446744073709551615 } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Word.Word64)
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "float" $ do
-            let expected = schemafy [Argo.schema| { "type": "number" } |]
+            let expected = schemafy
+                    (Just "number")
+                    [Argo.schema| { "type": "number" } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Float)
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "double" $ do
-            let expected = schemafy [Argo.schema| { "type": "number" } |]
+            let expected = schemafy
+                    (Just "number")
+                    [Argo.schema| { "type": "number" } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Double)
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "pointer" $ do
-            let expected = schemafy [Argo.schema| { "type": "string" } |]
+            let expected = schemafy
+                    (Just "string")
+                    [Argo.schema| { "type": "string" } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Argo.Pointer)
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "schema" $ do
-            let expected = schemafy [Argo.schema| true |]
+            let expected = schemafy (Just "value") [Argo.schema| true |]
                 actual =
                     Codec.schema (Argo.codec :: Codec.Value Schema.Schema)
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "record" $ do
-            let expected =
-                    schemafy
-                        [Argo.schema| { "type": "object", "properties": { "bool": { "type": "boolean" }, "text": { "type": "string" } }, "required": [ "bool" ], "additionalProperties": true } |]
+            let expected = schemafy
+                    Nothing
+                    [Argo.schema| { "type": "object", "properties": { "bool": { "type": "boolean" }, "text": { "type": "string" } }, "required": [ "bool" ], "additionalProperties": true } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Record)
             Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         ]
@@ -1077,7 +1116,9 @@ main = Tasty.defaultMain $ Tasty.testGroup
         $ let codec = Argo.codec :: Codec.Value T1
           in
               [ Tasty.testCase "schema" $ do
-                  let expected = schemafy [Argo.schema|
+                  let expected = schemafy
+                          Nothing
+                          [Argo.schema|
                             {
                                 "type": "object",
                                 "properties": {
@@ -1206,9 +1247,10 @@ hush :: Either String a -> Maybe a
 hush = either (const Nothing) Just
 
 schemafy
-    :: Schema.Schema
+    :: Maybe Identifier.Identifier
+    -> Schema.Schema
     -> Accum.AccumT
            (Map.Map Identifier.Identifier Schema.Schema)
            Identity.Identity
            (Maybe Identifier.Identifier, Schema.Schema)
-schemafy = pure . (,) Nothing
+schemafy m = pure . maybe Schema.unidentified Schema.identified m

--- a/source/test-suite/Main.hs
+++ b/source/test-suite/Main.hs
@@ -21,6 +21,7 @@ import qualified Argo.Schema.Identifier as Identifier
 import qualified Argo.Schema.Schema as Schema
 import qualified Argo.Type.Decimal as Decimal
 import qualified Argo.Type.Permission as Permission
+import qualified Control.Monad.Trans.Accum as Accum
 import qualified Data.ByteString as ByteString
 import qualified Data.ByteString.Builder as Builder
 import qualified Data.ByteString.Lazy as LazyByteString
@@ -738,26 +739,26 @@ main = Tasty.defaultMain $ Tasty.testGroup
         [ Tasty.testCase "value" $ do
             let expected = schemafy [Argo.schema| true |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Argo.Value)
-            actual @?= expected
+            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "null" $ do
             let expected = schemafy [Argo.schema| { "type": "null" } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Null.Null)
-            actual @?= expected
+            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "boolean" $ do
             let expected = schemafy [Argo.schema| { "type": "boolean" } |]
                 actual =
                     Codec.schema (Argo.codec :: Codec.Value Boolean.Boolean)
-            actual @?= expected
+            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "number" $ do
             let expected = schemafy [Argo.schema| { "type": "number" } |]
                 actual =
                     Codec.schema (Argo.codec :: Codec.Value Number.Number)
-            actual @?= expected
+            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "string" $ do
             let expected = schemafy [Argo.schema| { "type": "string" } |]
                 actual =
                     Codec.schema (Argo.codec :: Codec.Value String.String)
-            actual @?= expected
+            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "array boolean" $ do
             let expected =
                     schemafy
@@ -767,7 +768,7 @@ main = Tasty.defaultMain $ Tasty.testGroup
                         (Argo.codec :: Codec.Value
                               (Array.Array Boolean.Boolean)
                         )
-            actual @?= expected
+            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "object boolean" $ do
             let expected =
                     schemafy
@@ -777,14 +778,14 @@ main = Tasty.defaultMain $ Tasty.testGroup
                         (Argo.codec :: Codec.Value
                               (Object.Object Boolean.Boolean)
                         )
-            actual @?= expected
+            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "maybe boolean" $ do
             let expected =
                     schemafy
                         [Argo.schema| { "oneOf": [ { "type": "boolean" }, { "type": "null" } ] } |]
                 actual = Codec.schema
                     (Argo.codec :: Codec.Value (Maybe Boolean.Boolean))
-            actual @?= expected
+            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "either boolean number" $ do
             let expected =
                     schemafy
@@ -794,20 +795,20 @@ main = Tasty.defaultMain $ Tasty.testGroup
                         (Argo.codec :: Codec.Value
                               (Either Boolean.Boolean Number.Number)
                         )
-            actual @?= expected
+            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "()" $ do
             let expected =
                     schemafy
                         [Argo.schema| { "type": "array", "items": [], "additionalItems": false } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value ())
-            actual @?= expected
+            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "2-tuple" $ do
             let expected = schemafy [Argo.schema| { "type": "array", "items":
                         [ { "type": "boolean" }
                         , { "type": "boolean" }
                         ], "additionalItems": false } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value (Bool, Bool))
-            actual @?= expected
+            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "3-tuple" $ do
             let expected = schemafy [Argo.schema| { "type": "array", "items":
                         [ { "type": "boolean" }
@@ -816,7 +817,7 @@ main = Tasty.defaultMain $ Tasty.testGroup
                         ], "additionalItems": false } |]
                 actual = Codec.schema
                     (Argo.codec :: Codec.Value (Bool, Bool, Bool))
-            actual @?= expected
+            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "4-tuple" $ do
             let expected = schemafy [Argo.schema| { "type": "array", "items":
                         [ { "type": "boolean" }
@@ -827,7 +828,7 @@ main = Tasty.defaultMain $ Tasty.testGroup
                 actual =
                     Codec.schema
                         (Argo.codec :: Codec.Value (Bool, Bool, Bool, Bool))
-            actual @?= expected
+            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "5-tuple" $ do
             let expected = schemafy [Argo.schema| { "type": "array", "items":
                         [ { "type": "boolean" }
@@ -841,7 +842,7 @@ main = Tasty.defaultMain $ Tasty.testGroup
                         (Argo.codec :: Codec.Value
                               (Bool, Bool, Bool, Bool, Bool)
                         )
-            actual @?= expected
+            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "6-tuple" $ do
             let expected = schemafy [Argo.schema| { "type": "array", "items":
                         [ { "type": "boolean" }
@@ -856,7 +857,7 @@ main = Tasty.defaultMain $ Tasty.testGroup
                         (Argo.codec :: Codec.Value
                               (Bool, Bool, Bool, Bool, Bool, Bool)
                         )
-            actual @?= expected
+            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "7-tuple" $ do
             let expected = schemafy [Argo.schema| { "type": "array", "items":
                         [ { "type": "boolean" }
@@ -871,7 +872,7 @@ main = Tasty.defaultMain $ Tasty.testGroup
                     (Argo.codec :: Codec.Value
                           (Bool, Bool, Bool, Bool, Bool, Bool, Bool)
                     )
-            actual @?= expected
+            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "8-tuple" $ do
             let expected = schemafy [Argo.schema| { "type": "array", "items":
                         [ { "type": "boolean" }
@@ -887,27 +888,27 @@ main = Tasty.defaultMain $ Tasty.testGroup
                     (Argo.codec :: Codec.Value
                           (Bool, Bool, Bool, Bool, Bool, Bool, Bool, Bool)
                     )
-            actual @?= expected
+            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "bool" $ do
             let expected = schemafy [Argo.schema| { "type": "boolean" } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Bool)
-            actual @?= expected
+            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "decimal" $ do
             let expected = schemafy [Argo.schema| { "type": "number" } |]
                 actual =
                     Codec.schema (Argo.codec :: Codec.Value Decimal.Decimal)
-            actual @?= expected
+            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "text" $ do
             let expected = schemafy [Argo.schema| { "type": "string" } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Text.Text)
-            actual @?= expected
+            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "list boolean" $ do
             let expected =
                     schemafy
                         [Argo.schema| { "type": "array", "items": { "type": "boolean" } } |]
                 actual =
                     Codec.schema (Argo.codec :: Codec.Value [Boolean.Boolean])
-            actual @?= expected
+            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "map name boolean" $ do
             let expected =
                     schemafy
@@ -917,7 +918,7 @@ main = Tasty.defaultMain $ Tasty.testGroup
                         (Argo.codec :: Codec.Value
                               (Map.Map Name.Name Boolean.Boolean)
                         )
-            actual @?= expected
+            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "map (argo) string boolean" $ do
             let expected =
                     schemafy
@@ -926,7 +927,7 @@ main = Tasty.defaultMain $ Tasty.testGroup
                     (Argo.codec :: Codec.Value
                           (Map.Map String.String Boolean.Boolean)
                     )
-            actual @?= expected
+            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "map (strict) text boolean" $ do
             let expected =
                     schemafy
@@ -936,7 +937,7 @@ main = Tasty.defaultMain $ Tasty.testGroup
                         (Argo.codec :: Codec.Value
                               (Map.Map Text.Text Boolean.Boolean)
                         )
-            actual @?= expected
+            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "map (lazy) text boolean" $ do
             let expected =
                     schemafy
@@ -945,7 +946,7 @@ main = Tasty.defaultMain $ Tasty.testGroup
                     (Argo.codec :: Codec.Value
                           (Map.Map LazyText.Text Boolean.Boolean)
                     )
-            actual @?= expected
+            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "map (base) string boolean" $ do
             let expected =
                     schemafy
@@ -955,122 +956,122 @@ main = Tasty.defaultMain $ Tasty.testGroup
                         (Argo.codec :: Codec.Value
                               (Map.Map String Boolean.Boolean)
                         )
-            actual @?= expected
+            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "string" $ do
             let expected = schemafy [Argo.schema| { "type": "string" } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value String)
-            actual @?= expected
+            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "char" $ do
             let expected =
                     schemafy
                         [Argo.schema| { "type": "string", "minLength": 1, "maxLength": 1 } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Char)
-            actual @?= expected
+            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "lazy text" $ do
             let expected = schemafy [Argo.schema| { "type": "string" } |]
                 actual =
                     Codec.schema (Argo.codec :: Codec.Value LazyText.Text)
-            actual @?= expected
+            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "list boolean" $ do
             let expected =
                     schemafy
                         [Argo.schema| { "type": "array", "items": { "type": "boolean" }, "minItems": 1 } |]
                 actual = Codec.schema
                     (Argo.codec :: Codec.Value (NonEmpty Boolean.Boolean))
-            actual @?= expected
+            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "integer" $ do
             let expected = schemafy [Argo.schema| { "type": "integer" } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Integer)
-            actual @?= expected
+            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "int" $ do
             let expected =
                     schemafy
                         [Argo.schema| { "type": "integer", "minimum": -9223372036854775808, "maximum": 9223372036854775807 } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Int)
-            actual @?= expected
+            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "int8" $ do
             let expected =
                     schemafy
                         [Argo.schema| { "type": "integer", "minimum": -128, "maximum": 127 } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Int.Int8)
-            actual @?= expected
+            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "int16" $ do
             let expected =
                     schemafy
                         [Argo.schema| { "type": "integer", "minimum": -32768, "maximum": 32767 } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Int.Int16)
-            actual @?= expected
+            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "int32" $ do
             let expected =
                     schemafy
                         [Argo.schema| { "type": "integer", "minimum": -2147483648, "maximum": 2147483647 } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Int.Int32)
-            actual @?= expected
+            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "int64" $ do
             let expected =
                     schemafy
                         [Argo.schema| { "type": "integer", "minimum": -9223372036854775808, "maximum": 9223372036854775807 } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Int.Int64)
-            actual @?= expected
+            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "natural" $ do
             let expected = schemafy
                     [Argo.schema| { "type": "integer", "minimum": 0 } |]
                 actual =
                     Codec.schema (Argo.codec :: Codec.Value Natural.Natural)
-            actual @?= expected
+            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "word" $ do
             let expected =
                     schemafy
                         [Argo.schema| { "type": "integer", "minimum": 0, "maximum": 18446744073709551615 } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Word)
-            actual @?= expected
+            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "word8" $ do
             let expected =
                     schemafy
                         [Argo.schema| { "type": "integer", "minimum": 0, "maximum": 255 } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Word.Word8)
-            actual @?= expected
+            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "word16" $ do
             let expected =
                     schemafy
                         [Argo.schema| { "type": "integer", "minimum": 0, "maximum": 65535 } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Word.Word16)
-            actual @?= expected
+            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "word32" $ do
             let expected =
                     schemafy
                         [Argo.schema| { "type": "integer", "minimum": 0, "maximum": 4294967295 } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Word.Word32)
-            actual @?= expected
+            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "word64" $ do
             let expected =
                     schemafy
                         [Argo.schema| { "type": "integer", "minimum": 0, "maximum": 18446744073709551615 } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Word.Word64)
-            actual @?= expected
+            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "float" $ do
             let expected = schemafy [Argo.schema| { "type": "number" } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Float)
-            actual @?= expected
+            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "double" $ do
             let expected = schemafy [Argo.schema| { "type": "number" } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Double)
-            actual @?= expected
+            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "pointer" $ do
             let expected = schemafy [Argo.schema| { "type": "string" } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Argo.Pointer)
-            actual @?= expected
+            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "schema" $ do
             let expected = schemafy [Argo.schema| true |]
                 actual =
                     Codec.schema (Argo.codec :: Codec.Value Schema.Schema)
-            actual @?= expected
+            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         , Tasty.testCase "record" $ do
             let expected =
                     schemafy
                         [Argo.schema| { "type": "object", "properties": { "bool": { "type": "boolean" }, "text": { "type": "string" } }, "required": [ "bool" ], "additionalProperties": true } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Record)
-            actual @?= expected
+            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
         ]
     , Tasty.testGroup "T1"
         $ let codec = Argo.codec :: Codec.Value T1
@@ -1090,7 +1091,8 @@ main = Tasty.defaultMain $ Tasty.testGroup
                             }
                         |]
                       actual = Codec.schema codec
-                  actual @?= expected
+                  Accum.runAccum actual mempty
+                      @?= Accum.runAccum expected mempty
               , Tasty.testCase "decode" $ do
                   hush (Argo.decode "{ \"t1c1f1\": 0 }")
                       @?= (Nothing :: Maybe T1)
@@ -1205,5 +1207,8 @@ hush = either (const Nothing) Just
 
 schemafy
     :: Schema.Schema
-    -> Identity.Identity (Maybe Identifier.Identifier, Schema.Schema)
+    -> Accum.AccumT
+           ()
+           Identity.Identity
+           (Maybe Identifier.Identifier, Schema.Schema)
 schemafy = pure . (,) Nothing

--- a/source/test-suite/Main.hs
+++ b/source/test-suite/Main.hs
@@ -1215,16 +1215,16 @@ main = Tasty.defaultMain $ Tasty.testGroup
                       @?= "{\"t1c1f1\":4,\"t1c1f2\":null,\"t1c1f4\":0}"
               ]
     , Tasty.testCase "T2" $ do
-        let expected = schemafy
-                (Just "T2")
-                [Argo.schema|
-                        { "type": "object"
-                        , "properties": { "t2c1f1": { "$ref": "#/$defs/T2" } }
-                        , "required": []
-                        , "additionalProperties": true
-                        } |]
+        let schema = [Argo.schema|
+                { "type": "object"
+                , "properties": { "t2c1f1": { "$ref": "#/$defs/T2" } }
+                , "required": []
+                , "additionalProperties": true
+                } |]
+            expected = schemafy (Just "T2") schema
             actual = Codec.schema (Argo.codec :: Codec.Value T2)
-        Accum.evalAccumT actual mempty @?= Accum.evalAccumT expected mempty -- TODO: runAccumT
+        Accum.runAccum actual mempty
+            @?= (Accum.evalAccum expected mempty, Map.singleton "T2" schema)
     ]
 
 fromValue :: Argo.HasCodec a => Argo.Value -> Either String a

--- a/source/test-suite/Main.hs
+++ b/source/test-suite/Main.hs
@@ -769,7 +769,7 @@ main = Tasty.defaultMain $ Tasty.testGroup
         , Tasty.testCase "array boolean" $ do
             let expected = schemafy
                     (Just "Array Boolean")
-                    [Argo.schema| { "type": "array", "items": { "$ref": "#/$defs/Boolean" } } |]
+                    [Argo.schema| { "type": "array", "items": { "$ref": "#/definitions/Boolean" } } |]
                 actual =
                     Codec.schema
                         (Argo.codec :: Codec.Value
@@ -779,7 +779,7 @@ main = Tasty.defaultMain $ Tasty.testGroup
         , Tasty.testCase "object boolean" $ do
             let expected = schemafy
                     (Just "Object Boolean")
-                    [Argo.schema| { "type": "object", "additionalProperties": { "$ref": "#/$defs/Boolean" } } |]
+                    [Argo.schema| { "type": "object", "additionalProperties": { "$ref": "#/definitions/Boolean" } } |]
                 actual =
                     Codec.schema
                         (Argo.codec :: Codec.Value
@@ -796,7 +796,7 @@ main = Tasty.defaultMain $ Tasty.testGroup
         , Tasty.testCase "either boolean number" $ do
             let expected = schemafy
                     (Just "Either Boolean Number")
-                    [Argo.schema| { "oneOf": [ { "type": "object", "properties": { "type": { "const": "Left" }, "value": { "$ref": "#/$defs/Boolean" } }, "required": [ "type", "value" ], "additionalProperties": false }, { "type": "object", "properties": { "type": { "const": "Right" }, "value": { "$ref": "#/$defs/Number" } }, "required": [ "type", "value" ], "additionalProperties": false } ] } |]
+                    [Argo.schema| { "oneOf": [ { "type": "object", "properties": { "type": { "const": "Left" }, "value": { "$ref": "#/definitions/Boolean" } }, "required": [ "type", "value" ], "additionalProperties": false }, { "type": "object", "properties": { "type": { "const": "Right" }, "value": { "$ref": "#/definitions/Number" } }, "required": [ "type", "value" ], "additionalProperties": false } ] } |]
                 actual =
                     Codec.schema
                         (Argo.codec :: Codec.Value
@@ -813,8 +813,8 @@ main = Tasty.defaultMain $ Tasty.testGroup
             let expected = schemafy
                     (Just "(Value,Null)")
                     [Argo.schema| { "type": "array", "items":
-                        [ { "$ref": "#/$defs/Value" }
-                        , { "$ref": "#/$defs/Null" }
+                        [ { "$ref": "#/definitions/Value" }
+                        , { "$ref": "#/definitions/Null" }
                         ], "additionalItems": false } |]
                 actual = Codec.schema
                     (Argo.codec :: Codec.Value (Argo.Value, Null.Null))
@@ -823,9 +823,9 @@ main = Tasty.defaultMain $ Tasty.testGroup
             let expected = schemafy
                     (Just "(Value,Null,Boolean)")
                     [Argo.schema| { "type": "array", "items":
-                        [ { "$ref": "#/$defs/Value" }
-                        , { "$ref": "#/$defs/Null" }
-                        , { "$ref": "#/$defs/Boolean" }
+                        [ { "$ref": "#/definitions/Value" }
+                        , { "$ref": "#/definitions/Null" }
+                        , { "$ref": "#/definitions/Boolean" }
                         ], "additionalItems": false } |]
                 actual = Codec.schema
                     (Argo.codec :: Codec.Value
@@ -836,10 +836,10 @@ main = Tasty.defaultMain $ Tasty.testGroup
             let expected = schemafy
                     (Just "(Value,Null,Boolean,Number)")
                     [Argo.schema| { "type": "array", "items":
-                        [ { "$ref": "#/$defs/Value" }
-                        , { "$ref": "#/$defs/Null" }
-                        , { "$ref": "#/$defs/Boolean" }
-                        , { "$ref": "#/$defs/Number" }
+                        [ { "$ref": "#/definitions/Value" }
+                        , { "$ref": "#/definitions/Null" }
+                        , { "$ref": "#/definitions/Boolean" }
+                        , { "$ref": "#/definitions/Number" }
                         ], "additionalItems": false } |]
                 actual = Codec.schema
                     (Argo.codec :: Codec.Value
@@ -854,11 +854,11 @@ main = Tasty.defaultMain $ Tasty.testGroup
             let expected = schemafy
                     (Just "(Value,Null,Boolean,Number,Integer)")
                     [Argo.schema| { "type": "array", "items":
-                        [ { "$ref": "#/$defs/Value" }
-                        , { "$ref": "#/$defs/Null" }
-                        , { "$ref": "#/$defs/Boolean" }
-                        , { "$ref": "#/$defs/Number" }
-                        , { "$ref": "#/$defs/Integer" }
+                        [ { "$ref": "#/definitions/Value" }
+                        , { "$ref": "#/definitions/Null" }
+                        , { "$ref": "#/definitions/Boolean" }
+                        , { "$ref": "#/definitions/Number" }
+                        , { "$ref": "#/definitions/Integer" }
                         ], "additionalItems": false } |]
                 actual = Codec.schema
                     (Argo.codec :: Codec.Value
@@ -874,12 +874,12 @@ main = Tasty.defaultMain $ Tasty.testGroup
             let expected = schemafy
                     (Just "(Value,Null,Boolean,Number,Integer,String)")
                     [Argo.schema| { "type": "array", "items":
-                        [ { "$ref": "#/$defs/Value" }
-                        , { "$ref": "#/$defs/Null" }
-                        , { "$ref": "#/$defs/Boolean" }
-                        , { "$ref": "#/$defs/Number" }
-                        , { "$ref": "#/$defs/Integer" }
-                        , { "$ref": "#/$defs/String" }
+                        [ { "$ref": "#/definitions/Value" }
+                        , { "$ref": "#/definitions/Null" }
+                        , { "$ref": "#/definitions/Boolean" }
+                        , { "$ref": "#/definitions/Number" }
+                        , { "$ref": "#/definitions/Integer" }
+                        , { "$ref": "#/definitions/String" }
                         ], "additionalItems": false } |]
                 actual = Codec.schema
                     (Argo.codec :: Codec.Value
@@ -896,13 +896,13 @@ main = Tasty.defaultMain $ Tasty.testGroup
             let expected = schemafy
                     (Just "(Value,Null,Boolean,Number,Integer,String,())")
                     [Argo.schema| { "type": "array", "items":
-                        [ { "$ref": "#/$defs/Value" }
-                        , { "$ref": "#/$defs/Null" }
-                        , { "$ref": "#/$defs/Boolean" }
-                        , { "$ref": "#/$defs/Number" }
-                        , { "$ref": "#/$defs/Integer" }
-                        , { "$ref": "#/$defs/String" }
-                        , { "$ref": "#/$defs/()" }
+                        [ { "$ref": "#/definitions/Value" }
+                        , { "$ref": "#/definitions/Null" }
+                        , { "$ref": "#/definitions/Boolean" }
+                        , { "$ref": "#/definitions/Number" }
+                        , { "$ref": "#/definitions/Integer" }
+                        , { "$ref": "#/definitions/String" }
+                        , { "$ref": "#/definitions/()" }
                         ], "additionalItems": false } |]
                 actual = Codec.schema
                     (Argo.codec :: Codec.Value
@@ -920,14 +920,14 @@ main = Tasty.defaultMain $ Tasty.testGroup
             let expected = schemafy
                     (Just "(Value,Null,Boolean,Number,Integer,String,(),Char)")
                     [Argo.schema| { "type": "array", "items":
-                        [ { "$ref": "#/$defs/Value" }
-                        , { "$ref": "#/$defs/Null" }
-                        , { "$ref": "#/$defs/Boolean" }
-                        , { "$ref": "#/$defs/Number" }
-                        , { "$ref": "#/$defs/Integer" }
-                        , { "$ref": "#/$defs/String" }
-                        , { "$ref": "#/$defs/()" }
-                        , { "$ref": "#/$defs/Char" }
+                        [ { "$ref": "#/definitions/Value" }
+                        , { "$ref": "#/definitions/Null" }
+                        , { "$ref": "#/definitions/Boolean" }
+                        , { "$ref": "#/definitions/Number" }
+                        , { "$ref": "#/definitions/Integer" }
+                        , { "$ref": "#/definitions/String" }
+                        , { "$ref": "#/definitions/()" }
+                        , { "$ref": "#/definitions/Char" }
                         ], "additionalItems": false } |]
                 actual = Codec.schema
                     (Argo.codec :: Codec.Value
@@ -964,14 +964,14 @@ main = Tasty.defaultMain $ Tasty.testGroup
         , Tasty.testCase "list boolean" $ do
             let expected = schemafy
                     (Just "[Boolean]")
-                    [Argo.schema| { "type": "array", "items": { "$ref": "#/$defs/Boolean" } } |]
+                    [Argo.schema| { "type": "array", "items": { "$ref": "#/definitions/Boolean" } } |]
                 actual =
                     Codec.schema (Argo.codec :: Codec.Value [Boolean.Boolean])
             Accum.evalAccumT actual mempty @?= Accum.evalAccumT expected mempty
         , Tasty.testCase "map name boolean" $ do
             let expected = schemafy
                     (Just "Map Name Boolean")
-                    [Argo.schema| { "type": "object", "additionalProperties": { "$ref": "#/$defs/Boolean" } } |]
+                    [Argo.schema| { "type": "object", "additionalProperties": { "$ref": "#/definitions/Boolean" } } |]
                 actual =
                     Codec.schema
                         (Argo.codec :: Codec.Value
@@ -981,7 +981,7 @@ main = Tasty.defaultMain $ Tasty.testGroup
         , Tasty.testCase "map (argo) string boolean" $ do
             let expected = schemafy
                     (Just "Map String Boolean")
-                    [Argo.schema| { "type": "object", "additionalProperties": { "$ref": "#/$defs/Boolean" } } |]
+                    [Argo.schema| { "type": "object", "additionalProperties": { "$ref": "#/definitions/Boolean" } } |]
                 actual = Codec.schema
                     (Argo.codec :: Codec.Value
                           (Map.Map String.String Boolean.Boolean)
@@ -990,7 +990,7 @@ main = Tasty.defaultMain $ Tasty.testGroup
         , Tasty.testCase "map (strict) text boolean" $ do
             let expected = schemafy
                     (Just "Map Text Boolean")
-                    [Argo.schema| { "type": "object", "additionalProperties": { "$ref": "#/$defs/Boolean" } } |]
+                    [Argo.schema| { "type": "object", "additionalProperties": { "$ref": "#/definitions/Boolean" } } |]
                 actual =
                     Codec.schema
                         (Argo.codec :: Codec.Value
@@ -1000,7 +1000,7 @@ main = Tasty.defaultMain $ Tasty.testGroup
         , Tasty.testCase "map (lazy) text boolean" $ do
             let expected = schemafy
                     (Just "Map Text Boolean")
-                    [Argo.schema| { "type": "object", "additionalProperties": { "$ref": "#/$defs/Boolean" } } |]
+                    [Argo.schema| { "type": "object", "additionalProperties": { "$ref": "#/definitions/Boolean" } } |]
                 actual = Codec.schema
                     (Argo.codec :: Codec.Value
                           (Map.Map LazyText.Text Boolean.Boolean)
@@ -1009,7 +1009,7 @@ main = Tasty.defaultMain $ Tasty.testGroup
         , Tasty.testCase "map (base) string boolean" $ do
             let expected = schemafy
                     (Just "Map [Char] Boolean")
-                    [Argo.schema| { "type": "object", "additionalProperties": { "$ref": "#/$defs/Boolean" } } |]
+                    [Argo.schema| { "type": "object", "additionalProperties": { "$ref": "#/definitions/Boolean" } } |]
                 actual =
                     Codec.schema
                         (Argo.codec :: Codec.Value
@@ -1141,7 +1141,7 @@ main = Tasty.defaultMain $ Tasty.testGroup
         , Tasty.testCase "record" $ do
             let expected = schemafy
                     Nothing
-                    [Argo.schema| { "type": "object", "properties": { "bool": { "$ref": "#/$defs/Bool" }, "text": { "$ref": "#/$defs/Text" } }, "required": [ "bool" ], "additionalProperties": true } |]
+                    [Argo.schema| { "type": "object", "properties": { "bool": { "$ref": "#/definitions/Bool" }, "text": { "$ref": "#/definitions/Text" } }, "required": [ "bool" ], "additionalProperties": true } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Record)
             Accum.evalAccumT actual mempty @?= Accum.evalAccumT expected mempty
         ]
@@ -1155,10 +1155,10 @@ main = Tasty.defaultMain $ Tasty.testGroup
                             {
                                 "type": "object",
                                 "properties": {
-                                    "t1c1f1": { "$ref": "#/$defs/Float" },
-                                    "t1c1f2": { "$ref": "#/$defs/Maybe Float" },
-                                    "t1c1f3": { "$ref": "#/$defs/Float" },
-                                    "t1c1f4": { "$ref": "#/$defs/Maybe Float" }
+                                    "t1c1f1": { "$ref": "#/definitions/Float" },
+                                    "t1c1f2": { "$ref": "#/definitions/Maybe Float" },
+                                    "t1c1f3": { "$ref": "#/definitions/Float" },
+                                    "t1c1f4": { "$ref": "#/definitions/Maybe Float" }
                                 },
                                 "required": [ "t1c1f1", "t1c1f2" ],
                                 "additionalProperties": true
@@ -1217,7 +1217,7 @@ main = Tasty.defaultMain $ Tasty.testGroup
     , Tasty.testCase "T2" $ do
         let schema = [Argo.schema|
                 { "type": "object"
-                , "properties": { "t2c1f1": { "$ref": "#/$defs/T2" } }
+                , "properties": { "t2c1f1": { "$ref": "#/definitions/T2" } }
                 , "required": []
                 , "additionalProperties": true
                 } |]

--- a/source/test-suite/Main.hs
+++ b/source/test-suite/Main.hs
@@ -17,6 +17,7 @@ import qualified Argo.Json.Null as Null
 import qualified Argo.Json.Number as Number
 import qualified Argo.Json.Object as Object
 import qualified Argo.Json.String as String
+import qualified Argo.Schema.Identifier as Identifier
 import qualified Argo.Schema.Schema as Schema
 import qualified Argo.Type.Decimal as Decimal
 import qualified Argo.Type.Permission as Permission
@@ -735,35 +736,31 @@ main = Tasty.defaultMain $ Tasty.testGroup
     , Tasty.testGroup
         "Schema"
         [ Tasty.testCase "value" $ do
-            let expected = Identity.Identity [Argo.schema| true |]
+            let expected = schemafy [Argo.schema| true |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Argo.Value)
             actual @?= expected
         , Tasty.testCase "null" $ do
-            let expected =
-                    Identity.Identity [Argo.schema| { "type": "null" } |]
+            let expected = schemafy [Argo.schema| { "type": "null" } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Null.Null)
             actual @?= expected
         , Tasty.testCase "boolean" $ do
-            let expected =
-                    Identity.Identity [Argo.schema| { "type": "boolean" } |]
+            let expected = schemafy [Argo.schema| { "type": "boolean" } |]
                 actual =
                     Codec.schema (Argo.codec :: Codec.Value Boolean.Boolean)
             actual @?= expected
         , Tasty.testCase "number" $ do
-            let expected =
-                    Identity.Identity [Argo.schema| { "type": "number" } |]
+            let expected = schemafy [Argo.schema| { "type": "number" } |]
                 actual =
                     Codec.schema (Argo.codec :: Codec.Value Number.Number)
             actual @?= expected
         , Tasty.testCase "string" $ do
-            let expected =
-                    Identity.Identity [Argo.schema| { "type": "string" } |]
+            let expected = schemafy [Argo.schema| { "type": "string" } |]
                 actual =
                     Codec.schema (Argo.codec :: Codec.Value String.String)
             actual @?= expected
         , Tasty.testCase "array boolean" $ do
             let expected =
-                    Identity.Identity
+                    schemafy
                         [Argo.schema| { "type": "array", "items": { "type": "boolean" } } |]
                 actual =
                     Codec.schema
@@ -773,7 +770,7 @@ main = Tasty.defaultMain $ Tasty.testGroup
             actual @?= expected
         , Tasty.testCase "object boolean" $ do
             let expected =
-                    Identity.Identity
+                    schemafy
                         [Argo.schema| { "type": "object", "additionalProperties": { "type": "boolean" } } |]
                 actual =
                     Codec.schema
@@ -783,14 +780,14 @@ main = Tasty.defaultMain $ Tasty.testGroup
             actual @?= expected
         , Tasty.testCase "maybe boolean" $ do
             let expected =
-                    Identity.Identity
+                    schemafy
                         [Argo.schema| { "oneOf": [ { "type": "boolean" }, { "type": "null" } ] } |]
                 actual = Codec.schema
                     (Argo.codec :: Codec.Value (Maybe Boolean.Boolean))
             actual @?= expected
         , Tasty.testCase "either boolean number" $ do
             let expected =
-                    Identity.Identity
+                    schemafy
                         [Argo.schema| { "oneOf": [ { "type": "object", "properties": { "type": { "const": "Left" }, "value": { "type": "boolean" } }, "required": [ "type", "value" ], "additionalProperties": false }, { "type": "object", "properties": { "type": { "const": "Right" }, "value": { "type": "number" } }, "required": [ "type", "value" ], "additionalProperties": false } ] } |]
                 actual =
                     Codec.schema
@@ -800,42 +797,39 @@ main = Tasty.defaultMain $ Tasty.testGroup
             actual @?= expected
         , Tasty.testCase "()" $ do
             let expected =
-                    Identity.Identity
+                    schemafy
                         [Argo.schema| { "type": "array", "items": [], "additionalItems": false } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value ())
             actual @?= expected
         , Tasty.testCase "2-tuple" $ do
-            let expected = Identity.Identity
-                    [Argo.schema| { "type": "array", "items":
+            let expected = schemafy [Argo.schema| { "type": "array", "items":
                         [ { "type": "boolean" }
                         , { "type": "boolean" }
                         ], "additionalItems": false } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value (Bool, Bool))
             actual @?= expected
         , Tasty.testCase "3-tuple" $ do
-            let expected = Identity.Identity
-                    [Argo.schema| { "type": "array", "items":
+            let expected = schemafy [Argo.schema| { "type": "array", "items":
                         [ { "type": "boolean" }
-                        , { "type": "boolean" }
-                        , { "type": "boolean" }
-                        ], "additionalItems": false } |]
-                actual =
-                    Codec.schema (Argo.codec :: Codec.Value (Bool, Bool, Bool))
-            actual @?= expected
-        , Tasty.testCase "4-tuple" $ do
-            let expected = Identity.Identity
-                    [Argo.schema| { "type": "array", "items":
-                        [ { "type": "boolean" }
-                        , { "type": "boolean" }
                         , { "type": "boolean" }
                         , { "type": "boolean" }
                         ], "additionalItems": false } |]
                 actual = Codec.schema
-                    (Argo.codec :: Codec.Value (Bool, Bool, Bool, Bool))
+                    (Argo.codec :: Codec.Value (Bool, Bool, Bool))
+            actual @?= expected
+        , Tasty.testCase "4-tuple" $ do
+            let expected = schemafy [Argo.schema| { "type": "array", "items":
+                        [ { "type": "boolean" }
+                        , { "type": "boolean" }
+                        , { "type": "boolean" }
+                        , { "type": "boolean" }
+                        ], "additionalItems": false } |]
+                actual =
+                    Codec.schema
+                        (Argo.codec :: Codec.Value (Bool, Bool, Bool, Bool))
             actual @?= expected
         , Tasty.testCase "5-tuple" $ do
-            let expected = Identity.Identity
-                    [Argo.schema| { "type": "array", "items":
+            let expected = schemafy [Argo.schema| { "type": "array", "items":
                         [ { "type": "boolean" }
                         , { "type": "boolean" }
                         , { "type": "boolean" }
@@ -849,8 +843,7 @@ main = Tasty.defaultMain $ Tasty.testGroup
                         )
             actual @?= expected
         , Tasty.testCase "6-tuple" $ do
-            let expected = Identity.Identity
-                    [Argo.schema| { "type": "array", "items":
+            let expected = schemafy [Argo.schema| { "type": "array", "items":
                         [ { "type": "boolean" }
                         , { "type": "boolean" }
                         , { "type": "boolean" }
@@ -865,8 +858,7 @@ main = Tasty.defaultMain $ Tasty.testGroup
                         )
             actual @?= expected
         , Tasty.testCase "7-tuple" $ do
-            let expected = Identity.Identity
-                    [Argo.schema| { "type": "array", "items":
+            let expected = schemafy [Argo.schema| { "type": "array", "items":
                         [ { "type": "boolean" }
                         , { "type": "boolean" }
                         , { "type": "boolean" }
@@ -881,8 +873,7 @@ main = Tasty.defaultMain $ Tasty.testGroup
                     )
             actual @?= expected
         , Tasty.testCase "8-tuple" $ do
-            let expected = Identity.Identity
-                    [Argo.schema| { "type": "array", "items":
+            let expected = schemafy [Argo.schema| { "type": "array", "items":
                         [ { "type": "boolean" }
                         , { "type": "boolean" }
                         , { "type": "boolean" }
@@ -898,31 +889,28 @@ main = Tasty.defaultMain $ Tasty.testGroup
                     )
             actual @?= expected
         , Tasty.testCase "bool" $ do
-            let expected =
-                    Identity.Identity [Argo.schema| { "type": "boolean" } |]
+            let expected = schemafy [Argo.schema| { "type": "boolean" } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Bool)
             actual @?= expected
         , Tasty.testCase "decimal" $ do
-            let expected =
-                    Identity.Identity [Argo.schema| { "type": "number" } |]
+            let expected = schemafy [Argo.schema| { "type": "number" } |]
                 actual =
                     Codec.schema (Argo.codec :: Codec.Value Decimal.Decimal)
             actual @?= expected
         , Tasty.testCase "text" $ do
-            let expected =
-                    Identity.Identity [Argo.schema| { "type": "string" } |]
+            let expected = schemafy [Argo.schema| { "type": "string" } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Text.Text)
             actual @?= expected
         , Tasty.testCase "list boolean" $ do
             let expected =
-                    Identity.Identity
+                    schemafy
                         [Argo.schema| { "type": "array", "items": { "type": "boolean" } } |]
                 actual =
                     Codec.schema (Argo.codec :: Codec.Value [Boolean.Boolean])
             actual @?= expected
         , Tasty.testCase "map name boolean" $ do
             let expected =
-                    Identity.Identity
+                    schemafy
                         [Argo.schema| { "type": "object", "additionalProperties": { "type": "boolean" } } |]
                 actual =
                     Codec.schema
@@ -932,7 +920,7 @@ main = Tasty.defaultMain $ Tasty.testGroup
             actual @?= expected
         , Tasty.testCase "map (argo) string boolean" $ do
             let expected =
-                    Identity.Identity
+                    schemafy
                         [Argo.schema| { "type": "object", "additionalProperties": { "type": "boolean" } } |]
                 actual = Codec.schema
                     (Argo.codec :: Codec.Value
@@ -941,7 +929,7 @@ main = Tasty.defaultMain $ Tasty.testGroup
             actual @?= expected
         , Tasty.testCase "map (strict) text boolean" $ do
             let expected =
-                    Identity.Identity
+                    schemafy
                         [Argo.schema| { "type": "object", "additionalProperties": { "type": "boolean" } } |]
                 actual =
                     Codec.schema
@@ -951,7 +939,7 @@ main = Tasty.defaultMain $ Tasty.testGroup
             actual @?= expected
         , Tasty.testCase "map (lazy) text boolean" $ do
             let expected =
-                    Identity.Identity
+                    schemafy
                         [Argo.schema| { "type": "object", "additionalProperties": { "type": "boolean" } } |]
                 actual = Codec.schema
                     (Argo.codec :: Codec.Value
@@ -960,7 +948,7 @@ main = Tasty.defaultMain $ Tasty.testGroup
             actual @?= expected
         , Tasty.testCase "map (base) string boolean" $ do
             let expected =
-                    Identity.Identity
+                    schemafy
                         [Argo.schema| { "type": "object", "additionalProperties": { "type": "boolean" } } |]
                 actual =
                     Codec.schema
@@ -969,123 +957,117 @@ main = Tasty.defaultMain $ Tasty.testGroup
                         )
             actual @?= expected
         , Tasty.testCase "string" $ do
-            let expected =
-                    Identity.Identity [Argo.schema| { "type": "string" } |]
+            let expected = schemafy [Argo.schema| { "type": "string" } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value String)
             actual @?= expected
         , Tasty.testCase "char" $ do
             let expected =
-                    Identity.Identity
+                    schemafy
                         [Argo.schema| { "type": "string", "minLength": 1, "maxLength": 1 } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Char)
             actual @?= expected
         , Tasty.testCase "lazy text" $ do
-            let expected =
-                    Identity.Identity [Argo.schema| { "type": "string" } |]
+            let expected = schemafy [Argo.schema| { "type": "string" } |]
                 actual =
                     Codec.schema (Argo.codec :: Codec.Value LazyText.Text)
             actual @?= expected
         , Tasty.testCase "list boolean" $ do
             let expected =
-                    Identity.Identity
+                    schemafy
                         [Argo.schema| { "type": "array", "items": { "type": "boolean" }, "minItems": 1 } |]
                 actual = Codec.schema
                     (Argo.codec :: Codec.Value (NonEmpty Boolean.Boolean))
             actual @?= expected
         , Tasty.testCase "integer" $ do
-            let expected =
-                    Identity.Identity [Argo.schema| { "type": "integer" } |]
+            let expected = schemafy [Argo.schema| { "type": "integer" } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Integer)
             actual @?= expected
         , Tasty.testCase "int" $ do
             let expected =
-                    Identity.Identity
+                    schemafy
                         [Argo.schema| { "type": "integer", "minimum": -9223372036854775808, "maximum": 9223372036854775807 } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Int)
             actual @?= expected
         , Tasty.testCase "int8" $ do
             let expected =
-                    Identity.Identity
+                    schemafy
                         [Argo.schema| { "type": "integer", "minimum": -128, "maximum": 127 } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Int.Int8)
             actual @?= expected
         , Tasty.testCase "int16" $ do
             let expected =
-                    Identity.Identity
+                    schemafy
                         [Argo.schema| { "type": "integer", "minimum": -32768, "maximum": 32767 } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Int.Int16)
             actual @?= expected
         , Tasty.testCase "int32" $ do
             let expected =
-                    Identity.Identity
+                    schemafy
                         [Argo.schema| { "type": "integer", "minimum": -2147483648, "maximum": 2147483647 } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Int.Int32)
             actual @?= expected
         , Tasty.testCase "int64" $ do
             let expected =
-                    Identity.Identity
+                    schemafy
                         [Argo.schema| { "type": "integer", "minimum": -9223372036854775808, "maximum": 9223372036854775807 } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Int.Int64)
             actual @?= expected
         , Tasty.testCase "natural" $ do
-            let expected = Identity.Identity
+            let expected = schemafy
                     [Argo.schema| { "type": "integer", "minimum": 0 } |]
                 actual =
                     Codec.schema (Argo.codec :: Codec.Value Natural.Natural)
             actual @?= expected
         , Tasty.testCase "word" $ do
             let expected =
-                    Identity.Identity
+                    schemafy
                         [Argo.schema| { "type": "integer", "minimum": 0, "maximum": 18446744073709551615 } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Word)
             actual @?= expected
         , Tasty.testCase "word8" $ do
             let expected =
-                    Identity.Identity
+                    schemafy
                         [Argo.schema| { "type": "integer", "minimum": 0, "maximum": 255 } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Word.Word8)
             actual @?= expected
         , Tasty.testCase "word16" $ do
             let expected =
-                    Identity.Identity
+                    schemafy
                         [Argo.schema| { "type": "integer", "minimum": 0, "maximum": 65535 } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Word.Word16)
             actual @?= expected
         , Tasty.testCase "word32" $ do
             let expected =
-                    Identity.Identity
+                    schemafy
                         [Argo.schema| { "type": "integer", "minimum": 0, "maximum": 4294967295 } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Word.Word32)
             actual @?= expected
         , Tasty.testCase "word64" $ do
             let expected =
-                    Identity.Identity
+                    schemafy
                         [Argo.schema| { "type": "integer", "minimum": 0, "maximum": 18446744073709551615 } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Word.Word64)
             actual @?= expected
         , Tasty.testCase "float" $ do
-            let expected =
-                    Identity.Identity [Argo.schema| { "type": "number" } |]
+            let expected = schemafy [Argo.schema| { "type": "number" } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Float)
             actual @?= expected
         , Tasty.testCase "double" $ do
-            let expected =
-                    Identity.Identity [Argo.schema| { "type": "number" } |]
+            let expected = schemafy [Argo.schema| { "type": "number" } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Double)
             actual @?= expected
         , Tasty.testCase "pointer" $ do
-            let expected =
-                    Identity.Identity [Argo.schema| { "type": "string" } |]
+            let expected = schemafy [Argo.schema| { "type": "string" } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Argo.Pointer)
             actual @?= expected
         , Tasty.testCase "schema" $ do
-            let expected = Identity.Identity [Argo.schema| true |]
+            let expected = schemafy [Argo.schema| true |]
                 actual =
                     Codec.schema (Argo.codec :: Codec.Value Schema.Schema)
             actual @?= expected
         , Tasty.testCase "record" $ do
             let expected =
-                    Identity.Identity
+                    schemafy
                         [Argo.schema| { "type": "object", "properties": { "bool": { "type": "boolean" }, "text": { "type": "string" } }, "required": [ "bool" ], "additionalProperties": true } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Record)
             actual @?= expected
@@ -1094,7 +1076,7 @@ main = Tasty.defaultMain $ Tasty.testGroup
         $ let codec = Argo.codec :: Codec.Value T1
           in
               [ Tasty.testCase "schema" $ do
-                  let expected = Identity.Identity [Argo.schema|
+                  let expected = schemafy [Argo.schema|
                             {
                                 "type": "object",
                                 "properties": {
@@ -1220,3 +1202,8 @@ propertyWith n g s f =
 
 hush :: Either String a -> Maybe a
 hush = either (const Nothing) Just
+
+schemafy
+    :: Schema.Schema
+    -> Identity.Identity (Maybe Identifier.Identifier, Schema.Schema)
+schemafy = pure . (,) Nothing

--- a/source/test-suite/Main.hs
+++ b/source/test-suite/Main.hs
@@ -23,6 +23,7 @@ import qualified Argo.Type.Permission as Permission
 import qualified Data.ByteString as ByteString
 import qualified Data.ByteString.Builder as Builder
 import qualified Data.ByteString.Lazy as LazyByteString
+import qualified Data.Functor.Identity as Identity
 import qualified Data.Int as Int
 import qualified Data.Map as Map
 import qualified Data.Text as Text
@@ -734,32 +735,36 @@ main = Tasty.defaultMain $ Tasty.testGroup
     , Tasty.testGroup
         "Schema"
         [ Tasty.testCase "value" $ do
-            let expected = [Argo.schema| true |]
+            let expected = Identity.Identity [Argo.schema| true |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Argo.Value)
             actual @?= expected
         , Tasty.testCase "null" $ do
-            let expected = [Argo.schema| { "type": "null" } |]
+            let expected =
+                    Identity.Identity [Argo.schema| { "type": "null" } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Null.Null)
             actual @?= expected
         , Tasty.testCase "boolean" $ do
-            let expected = [Argo.schema| { "type": "boolean" } |]
+            let expected =
+                    Identity.Identity [Argo.schema| { "type": "boolean" } |]
                 actual =
                     Codec.schema (Argo.codec :: Codec.Value Boolean.Boolean)
             actual @?= expected
         , Tasty.testCase "number" $ do
-            let expected = [Argo.schema| { "type": "number" } |]
+            let expected =
+                    Identity.Identity [Argo.schema| { "type": "number" } |]
                 actual =
                     Codec.schema (Argo.codec :: Codec.Value Number.Number)
             actual @?= expected
         , Tasty.testCase "string" $ do
-            let expected = [Argo.schema| { "type": "string" } |]
+            let expected =
+                    Identity.Identity [Argo.schema| { "type": "string" } |]
                 actual =
                     Codec.schema (Argo.codec :: Codec.Value String.String)
             actual @?= expected
         , Tasty.testCase "array boolean" $ do
             let expected =
-                    Schema.fromValue
-                        [Argo.value| { "type": "array", "items": { "type": "boolean" } } |]
+                    Identity.Identity
+                        [Argo.schema| { "type": "array", "items": { "type": "boolean" } } |]
                 actual =
                     Codec.schema
                         (Argo.codec :: Codec.Value
@@ -768,8 +773,8 @@ main = Tasty.defaultMain $ Tasty.testGroup
             actual @?= expected
         , Tasty.testCase "object boolean" $ do
             let expected =
-                    Schema.fromValue
-                        [Argo.value| { "type": "object", "additionalProperties": { "type": "boolean" } } |]
+                    Identity.Identity
+                        [Argo.schema| { "type": "object", "additionalProperties": { "type": "boolean" } } |]
                 actual =
                     Codec.schema
                         (Argo.codec :: Codec.Value
@@ -778,15 +783,15 @@ main = Tasty.defaultMain $ Tasty.testGroup
             actual @?= expected
         , Tasty.testCase "maybe boolean" $ do
             let expected =
-                    Schema.fromValue
-                        [Argo.value| { "oneOf": [ { "type": "boolean" }, { "type": "null" } ] } |]
+                    Identity.Identity
+                        [Argo.schema| { "oneOf": [ { "type": "boolean" }, { "type": "null" } ] } |]
                 actual = Codec.schema
                     (Argo.codec :: Codec.Value (Maybe Boolean.Boolean))
             actual @?= expected
         , Tasty.testCase "either boolean number" $ do
             let expected =
-                    Schema.fromValue
-                        [Argo.value| { "oneOf": [ { "type": "object", "properties": { "type": { "const": "Left" }, "value": { "type": "boolean" } }, "required": [ "type", "value" ], "additionalProperties": false }, { "type": "object", "properties": { "type": { "const": "Right" }, "value": { "type": "number" } }, "required": [ "type", "value" ], "additionalProperties": false } ] } |]
+                    Identity.Identity
+                        [Argo.schema| { "oneOf": [ { "type": "object", "properties": { "type": { "const": "Left" }, "value": { "type": "boolean" } }, "required": [ "type", "value" ], "additionalProperties": false }, { "type": "object", "properties": { "type": { "const": "Right" }, "value": { "type": "number" } }, "required": [ "type", "value" ], "additionalProperties": false } ] } |]
                 actual =
                     Codec.schema
                         (Argo.codec :: Codec.Value
@@ -795,21 +800,21 @@ main = Tasty.defaultMain $ Tasty.testGroup
             actual @?= expected
         , Tasty.testCase "()" $ do
             let expected =
-                    Schema.fromValue
-                        [Argo.value| { "type": "array", "items": [], "additionalItems": false } |]
+                    Identity.Identity
+                        [Argo.schema| { "type": "array", "items": [], "additionalItems": false } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value ())
             actual @?= expected
         , Tasty.testCase "2-tuple" $ do
-            let expected = Schema.fromValue
-                    [Argo.value| { "type": "array", "items":
+            let expected = Identity.Identity
+                    [Argo.schema| { "type": "array", "items":
                         [ { "type": "boolean" }
                         , { "type": "boolean" }
                         ], "additionalItems": false } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value (Bool, Bool))
             actual @?= expected
         , Tasty.testCase "3-tuple" $ do
-            let expected = Schema.fromValue
-                    [Argo.value| { "type": "array", "items":
+            let expected = Identity.Identity
+                    [Argo.schema| { "type": "array", "items":
                         [ { "type": "boolean" }
                         , { "type": "boolean" }
                         , { "type": "boolean" }
@@ -818,8 +823,8 @@ main = Tasty.defaultMain $ Tasty.testGroup
                     Codec.schema (Argo.codec :: Codec.Value (Bool, Bool, Bool))
             actual @?= expected
         , Tasty.testCase "4-tuple" $ do
-            let expected = Schema.fromValue
-                    [Argo.value| { "type": "array", "items":
+            let expected = Identity.Identity
+                    [Argo.schema| { "type": "array", "items":
                         [ { "type": "boolean" }
                         , { "type": "boolean" }
                         , { "type": "boolean" }
@@ -829,8 +834,8 @@ main = Tasty.defaultMain $ Tasty.testGroup
                     (Argo.codec :: Codec.Value (Bool, Bool, Bool, Bool))
             actual @?= expected
         , Tasty.testCase "5-tuple" $ do
-            let expected = Schema.fromValue
-                    [Argo.value| { "type": "array", "items":
+            let expected = Identity.Identity
+                    [Argo.schema| { "type": "array", "items":
                         [ { "type": "boolean" }
                         , { "type": "boolean" }
                         , { "type": "boolean" }
@@ -844,8 +849,8 @@ main = Tasty.defaultMain $ Tasty.testGroup
                         )
             actual @?= expected
         , Tasty.testCase "6-tuple" $ do
-            let expected = Schema.fromValue
-                    [Argo.value| { "type": "array", "items":
+            let expected = Identity.Identity
+                    [Argo.schema| { "type": "array", "items":
                         [ { "type": "boolean" }
                         , { "type": "boolean" }
                         , { "type": "boolean" }
@@ -860,8 +865,8 @@ main = Tasty.defaultMain $ Tasty.testGroup
                         )
             actual @?= expected
         , Tasty.testCase "7-tuple" $ do
-            let expected = Schema.fromValue
-                    [Argo.value| { "type": "array", "items":
+            let expected = Identity.Identity
+                    [Argo.schema| { "type": "array", "items":
                         [ { "type": "boolean" }
                         , { "type": "boolean" }
                         , { "type": "boolean" }
@@ -876,8 +881,8 @@ main = Tasty.defaultMain $ Tasty.testGroup
                     )
             actual @?= expected
         , Tasty.testCase "8-tuple" $ do
-            let expected = Schema.fromValue
-                    [Argo.value| { "type": "array", "items":
+            let expected = Identity.Identity
+                    [Argo.schema| { "type": "array", "items":
                         [ { "type": "boolean" }
                         , { "type": "boolean" }
                         , { "type": "boolean" }
@@ -893,29 +898,32 @@ main = Tasty.defaultMain $ Tasty.testGroup
                     )
             actual @?= expected
         , Tasty.testCase "bool" $ do
-            let expected = [Argo.schema| { "type": "boolean" } |]
+            let expected =
+                    Identity.Identity [Argo.schema| { "type": "boolean" } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Bool)
             actual @?= expected
         , Tasty.testCase "decimal" $ do
-            let expected = [Argo.schema| { "type": "number" } |]
+            let expected =
+                    Identity.Identity [Argo.schema| { "type": "number" } |]
                 actual =
                     Codec.schema (Argo.codec :: Codec.Value Decimal.Decimal)
             actual @?= expected
         , Tasty.testCase "text" $ do
-            let expected = [Argo.schema| { "type": "string" } |]
+            let expected =
+                    Identity.Identity [Argo.schema| { "type": "string" } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Text.Text)
             actual @?= expected
         , Tasty.testCase "list boolean" $ do
             let expected =
-                    Schema.fromValue
-                        [Argo.value| { "type": "array", "items": { "type": "boolean" } } |]
+                    Identity.Identity
+                        [Argo.schema| { "type": "array", "items": { "type": "boolean" } } |]
                 actual =
                     Codec.schema (Argo.codec :: Codec.Value [Boolean.Boolean])
             actual @?= expected
         , Tasty.testCase "map name boolean" $ do
             let expected =
-                    Schema.fromValue
-                        [Argo.value| { "type": "object", "additionalProperties": { "type": "boolean" } } |]
+                    Identity.Identity
+                        [Argo.schema| { "type": "object", "additionalProperties": { "type": "boolean" } } |]
                 actual =
                     Codec.schema
                         (Argo.codec :: Codec.Value
@@ -924,8 +932,8 @@ main = Tasty.defaultMain $ Tasty.testGroup
             actual @?= expected
         , Tasty.testCase "map (argo) string boolean" $ do
             let expected =
-                    Schema.fromValue
-                        [Argo.value| { "type": "object", "additionalProperties": { "type": "boolean" } } |]
+                    Identity.Identity
+                        [Argo.schema| { "type": "object", "additionalProperties": { "type": "boolean" } } |]
                 actual = Codec.schema
                     (Argo.codec :: Codec.Value
                           (Map.Map String.String Boolean.Boolean)
@@ -933,8 +941,8 @@ main = Tasty.defaultMain $ Tasty.testGroup
             actual @?= expected
         , Tasty.testCase "map (strict) text boolean" $ do
             let expected =
-                    Schema.fromValue
-                        [Argo.value| { "type": "object", "additionalProperties": { "type": "boolean" } } |]
+                    Identity.Identity
+                        [Argo.schema| { "type": "object", "additionalProperties": { "type": "boolean" } } |]
                 actual =
                     Codec.schema
                         (Argo.codec :: Codec.Value
@@ -943,8 +951,8 @@ main = Tasty.defaultMain $ Tasty.testGroup
             actual @?= expected
         , Tasty.testCase "map (lazy) text boolean" $ do
             let expected =
-                    Schema.fromValue
-                        [Argo.value| { "type": "object", "additionalProperties": { "type": "boolean" } } |]
+                    Identity.Identity
+                        [Argo.schema| { "type": "object", "additionalProperties": { "type": "boolean" } } |]
                 actual = Codec.schema
                     (Argo.codec :: Codec.Value
                           (Map.Map LazyText.Text Boolean.Boolean)
@@ -952,8 +960,8 @@ main = Tasty.defaultMain $ Tasty.testGroup
             actual @?= expected
         , Tasty.testCase "map (base) string boolean" $ do
             let expected =
-                    Schema.fromValue
-                        [Argo.value| { "type": "object", "additionalProperties": { "type": "boolean" } } |]
+                    Identity.Identity
+                        [Argo.schema| { "type": "object", "additionalProperties": { "type": "boolean" } } |]
                 actual =
                     Codec.schema
                         (Argo.codec :: Codec.Value
@@ -961,117 +969,124 @@ main = Tasty.defaultMain $ Tasty.testGroup
                         )
             actual @?= expected
         , Tasty.testCase "string" $ do
-            let expected = [Argo.schema| { "type": "string" } |]
+            let expected =
+                    Identity.Identity [Argo.schema| { "type": "string" } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value String)
             actual @?= expected
         , Tasty.testCase "char" $ do
             let expected =
-                    Schema.fromValue
-                        [Argo.value| { "type": "string", "minLength": 1, "maxLength": 1 } |]
+                    Identity.Identity
+                        [Argo.schema| { "type": "string", "minLength": 1, "maxLength": 1 } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Char)
             actual @?= expected
         , Tasty.testCase "lazy text" $ do
-            let expected = [Argo.schema| { "type": "string" } |]
+            let expected =
+                    Identity.Identity [Argo.schema| { "type": "string" } |]
                 actual =
                     Codec.schema (Argo.codec :: Codec.Value LazyText.Text)
             actual @?= expected
         , Tasty.testCase "list boolean" $ do
             let expected =
-                    Schema.fromValue
-                        [Argo.value| { "type": "array", "items": { "type": "boolean" }, "minItems": 1 } |]
+                    Identity.Identity
+                        [Argo.schema| { "type": "array", "items": { "type": "boolean" }, "minItems": 1 } |]
                 actual = Codec.schema
                     (Argo.codec :: Codec.Value (NonEmpty Boolean.Boolean))
             actual @?= expected
         , Tasty.testCase "integer" $ do
-            let expected = [Argo.schema| { "type": "integer" } |]
+            let expected =
+                    Identity.Identity [Argo.schema| { "type": "integer" } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Integer)
             actual @?= expected
         , Tasty.testCase "int" $ do
             let expected =
-                    Schema.fromValue
-                        [Argo.value| { "type": "integer", "minimum": -9223372036854775808, "maximum": 9223372036854775807 } |]
+                    Identity.Identity
+                        [Argo.schema| { "type": "integer", "minimum": -9223372036854775808, "maximum": 9223372036854775807 } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Int)
             actual @?= expected
         , Tasty.testCase "int8" $ do
             let expected =
-                    Schema.fromValue
-                        [Argo.value| { "type": "integer", "minimum": -128, "maximum": 127 } |]
+                    Identity.Identity
+                        [Argo.schema| { "type": "integer", "minimum": -128, "maximum": 127 } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Int.Int8)
             actual @?= expected
         , Tasty.testCase "int16" $ do
             let expected =
-                    Schema.fromValue
-                        [Argo.value| { "type": "integer", "minimum": -32768, "maximum": 32767 } |]
+                    Identity.Identity
+                        [Argo.schema| { "type": "integer", "minimum": -32768, "maximum": 32767 } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Int.Int16)
             actual @?= expected
         , Tasty.testCase "int32" $ do
             let expected =
-                    Schema.fromValue
-                        [Argo.value| { "type": "integer", "minimum": -2147483648, "maximum": 2147483647 } |]
+                    Identity.Identity
+                        [Argo.schema| { "type": "integer", "minimum": -2147483648, "maximum": 2147483647 } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Int.Int32)
             actual @?= expected
         , Tasty.testCase "int64" $ do
             let expected =
-                    Schema.fromValue
-                        [Argo.value| { "type": "integer", "minimum": -9223372036854775808, "maximum": 9223372036854775807 } |]
+                    Identity.Identity
+                        [Argo.schema| { "type": "integer", "minimum": -9223372036854775808, "maximum": 9223372036854775807 } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Int.Int64)
             actual @?= expected
         , Tasty.testCase "natural" $ do
-            let expected = Schema.fromValue
-                    [Argo.value| { "type": "integer", "minimum": 0 } |]
+            let expected = Identity.Identity
+                    [Argo.schema| { "type": "integer", "minimum": 0 } |]
                 actual =
                     Codec.schema (Argo.codec :: Codec.Value Natural.Natural)
             actual @?= expected
         , Tasty.testCase "word" $ do
             let expected =
-                    Schema.fromValue
-                        [Argo.value| { "type": "integer", "minimum": 0, "maximum": 18446744073709551615 } |]
+                    Identity.Identity
+                        [Argo.schema| { "type": "integer", "minimum": 0, "maximum": 18446744073709551615 } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Word)
             actual @?= expected
         , Tasty.testCase "word8" $ do
             let expected =
-                    Schema.fromValue
-                        [Argo.value| { "type": "integer", "minimum": 0, "maximum": 255 } |]
+                    Identity.Identity
+                        [Argo.schema| { "type": "integer", "minimum": 0, "maximum": 255 } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Word.Word8)
             actual @?= expected
         , Tasty.testCase "word16" $ do
             let expected =
-                    Schema.fromValue
-                        [Argo.value| { "type": "integer", "minimum": 0, "maximum": 65535 } |]
+                    Identity.Identity
+                        [Argo.schema| { "type": "integer", "minimum": 0, "maximum": 65535 } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Word.Word16)
             actual @?= expected
         , Tasty.testCase "word32" $ do
             let expected =
-                    Schema.fromValue
-                        [Argo.value| { "type": "integer", "minimum": 0, "maximum": 4294967295 } |]
+                    Identity.Identity
+                        [Argo.schema| { "type": "integer", "minimum": 0, "maximum": 4294967295 } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Word.Word32)
             actual @?= expected
         , Tasty.testCase "word64" $ do
             let expected =
-                    Schema.fromValue
-                        [Argo.value| { "type": "integer", "minimum": 0, "maximum": 18446744073709551615 } |]
+                    Identity.Identity
+                        [Argo.schema| { "type": "integer", "minimum": 0, "maximum": 18446744073709551615 } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Word.Word64)
             actual @?= expected
         , Tasty.testCase "float" $ do
-            let expected = [Argo.schema| { "type": "number" } |]
+            let expected =
+                    Identity.Identity [Argo.schema| { "type": "number" } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Float)
             actual @?= expected
         , Tasty.testCase "double" $ do
-            let expected = [Argo.schema| { "type": "number" } |]
+            let expected =
+                    Identity.Identity [Argo.schema| { "type": "number" } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Double)
             actual @?= expected
         , Tasty.testCase "pointer" $ do
-            let expected = [Argo.schema| { "type": "string" } |]
+            let expected =
+                    Identity.Identity [Argo.schema| { "type": "string" } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Argo.Pointer)
             actual @?= expected
         , Tasty.testCase "schema" $ do
-            let expected = [Argo.schema| true |]
+            let expected = Identity.Identity [Argo.schema| true |]
                 actual =
                     Codec.schema (Argo.codec :: Codec.Value Schema.Schema)
             actual @?= expected
         , Tasty.testCase "record" $ do
-            let expected
-                    = [Argo.schema| { "type": "object", "properties": { "bool": { "type": "boolean" }, "text": { "type": "string" } }, "required": [ "bool" ], "additionalProperties": true } |]
+            let expected =
+                    Identity.Identity
+                        [Argo.schema| { "type": "object", "properties": { "bool": { "type": "boolean" }, "text": { "type": "string" } }, "required": [ "bool" ], "additionalProperties": true } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Record)
             actual @?= expected
         ]
@@ -1079,7 +1094,7 @@ main = Tasty.defaultMain $ Tasty.testGroup
         $ let codec = Argo.codec :: Codec.Value T1
           in
               [ Tasty.testCase "schema" $ do
-                  let expected = [Argo.schema|
+                  let expected = Identity.Identity [Argo.schema|
                             {
                                 "type": "object",
                                 "properties": {

--- a/source/test-suite/Main.hs
+++ b/source/test-suite/Main.hs
@@ -796,7 +796,7 @@ main = Tasty.defaultMain $ Tasty.testGroup
         , Tasty.testCase "either boolean number" $ do
             let expected = schemafy
                     (Just "Either Boolean Number")
-                    [Argo.schema| { "oneOf": [ { "type": "object", "properties": { "type": { "const": "Left" }, "value": { "type": "boolean" } }, "required": [ "type", "value" ], "additionalProperties": false }, { "type": "object", "properties": { "type": { "const": "Right" }, "value": { "type": "number" } }, "required": [ "type", "value" ], "additionalProperties": false } ] } |]
+                    [Argo.schema| { "oneOf": [ { "type": "object", "properties": { "type": { "const": "Left" }, "value": { "$ref": "#/$defs/Boolean" } }, "required": [ "type", "value" ], "additionalProperties": false }, { "type": "object", "properties": { "type": { "const": "Right" }, "value": { "$ref": "#/$defs/Number" } }, "required": [ "type", "value" ], "additionalProperties": false } ] } |]
                 actual =
                     Codec.schema
                         (Argo.codec :: Codec.Value
@@ -813,8 +813,8 @@ main = Tasty.defaultMain $ Tasty.testGroup
             let expected = schemafy
                     (Just "(Value,Null)")
                     [Argo.schema| { "type": "array", "items":
-                        [ true
-                        , { "type": "null" }
+                        [ { "$ref": "#/$defs/Value" }
+                        , { "$ref": "#/$defs/Null" }
                         ], "additionalItems": false } |]
                 actual = Codec.schema
                     (Argo.codec :: Codec.Value (Argo.Value, Null.Null))
@@ -823,9 +823,9 @@ main = Tasty.defaultMain $ Tasty.testGroup
             let expected = schemafy
                     (Just "(Value,Null,Boolean)")
                     [Argo.schema| { "type": "array", "items":
-                        [ true
-                        , { "type": "null" }
-                        , { "type": "boolean" }
+                        [ { "$ref": "#/$defs/Value" }
+                        , { "$ref": "#/$defs/Null" }
+                        , { "$ref": "#/$defs/Boolean" }
                         ], "additionalItems": false } |]
                 actual = Codec.schema
                     (Argo.codec :: Codec.Value
@@ -836,10 +836,10 @@ main = Tasty.defaultMain $ Tasty.testGroup
             let expected = schemafy
                     (Just "(Value,Null,Boolean,Number)")
                     [Argo.schema| { "type": "array", "items":
-                        [ true
-                        , { "type": "null" }
-                        , { "type": "boolean" }
-                        , { "type": "number" }
+                        [ { "$ref": "#/$defs/Value" }
+                        , { "$ref": "#/$defs/Null" }
+                        , { "$ref": "#/$defs/Boolean" }
+                        , { "$ref": "#/$defs/Number" }
                         ], "additionalItems": false } |]
                 actual = Codec.schema
                     (Argo.codec :: Codec.Value
@@ -854,11 +854,11 @@ main = Tasty.defaultMain $ Tasty.testGroup
             let expected = schemafy
                     (Just "(Value,Null,Boolean,Number,Integer)")
                     [Argo.schema| { "type": "array", "items":
-                        [ true
-                        , { "type": "null" }
-                        , { "type": "boolean" }
-                        , { "type": "number" }
-                        , { "type": "integer" }
+                        [ { "$ref": "#/$defs/Value" }
+                        , { "$ref": "#/$defs/Null" }
+                        , { "$ref": "#/$defs/Boolean" }
+                        , { "$ref": "#/$defs/Number" }
+                        , { "$ref": "#/$defs/Integer" }
                         ], "additionalItems": false } |]
                 actual = Codec.schema
                     (Argo.codec :: Codec.Value
@@ -874,12 +874,12 @@ main = Tasty.defaultMain $ Tasty.testGroup
             let expected = schemafy
                     (Just "(Value,Null,Boolean,Number,Integer,String)")
                     [Argo.schema| { "type": "array", "items":
-                        [ true
-                        , { "type": "null" }
-                        , { "type": "boolean" }
-                        , { "type": "number" }
-                        , { "type": "integer" }
-                        , { "type": "string" }
+                        [ { "$ref": "#/$defs/Value" }
+                        , { "$ref": "#/$defs/Null" }
+                        , { "$ref": "#/$defs/Boolean" }
+                        , { "$ref": "#/$defs/Number" }
+                        , { "$ref": "#/$defs/Integer" }
+                        , { "$ref": "#/$defs/String" }
                         ], "additionalItems": false } |]
                 actual = Codec.schema
                     (Argo.codec :: Codec.Value
@@ -896,13 +896,13 @@ main = Tasty.defaultMain $ Tasty.testGroup
             let expected = schemafy
                     (Just "(Value,Null,Boolean,Number,Integer,String,())")
                     [Argo.schema| { "type": "array", "items":
-                        [ true
-                        , { "type": "null" }
-                        , { "type": "boolean" }
-                        , { "type": "number" }
-                        , { "type": "integer" }
-                        , { "type": "string" }
-                        , { "type": "array", "items": [], "additionalItems": false }
+                        [ { "$ref": "#/$defs/Value" }
+                        , { "$ref": "#/$defs/Null" }
+                        , { "$ref": "#/$defs/Boolean" }
+                        , { "$ref": "#/$defs/Number" }
+                        , { "$ref": "#/$defs/Integer" }
+                        , { "$ref": "#/$defs/String" }
+                        , { "$ref": "#/$defs/()" }
                         ], "additionalItems": false } |]
                 actual = Codec.schema
                     (Argo.codec :: Codec.Value
@@ -920,14 +920,14 @@ main = Tasty.defaultMain $ Tasty.testGroup
             let expected = schemafy
                     (Just "(Value,Null,Boolean,Number,Integer,String,(),Char)")
                     [Argo.schema| { "type": "array", "items":
-                        [ true
-                        , { "type": "null" }
-                        , { "type": "boolean" }
-                        , { "type": "number" }
-                        , { "type": "integer" }
-                        , { "type": "string" }
-                        , { "type": "array", "items": [], "additionalItems": false }
-                        , { "type": "string", "minLength": 1, "maxLength": 1 }
+                        [ { "$ref": "#/$defs/Value" }
+                        , { "$ref": "#/$defs/Null" }
+                        , { "$ref": "#/$defs/Boolean" }
+                        , { "$ref": "#/$defs/Number" }
+                        , { "$ref": "#/$defs/Integer" }
+                        , { "$ref": "#/$defs/String" }
+                        , { "$ref": "#/$defs/()" }
+                        , { "$ref": "#/$defs/Char" }
                         ], "additionalItems": false } |]
                 actual = Codec.schema
                     (Argo.codec :: Codec.Value
@@ -1140,8 +1140,8 @@ main = Tasty.defaultMain $ Tasty.testGroup
             Accum.evalAccumT actual mempty @?= Accum.evalAccumT expected mempty
         , Tasty.testCase "record" $ do
             let expected = schemafy
-                    Nothing  -- TODO
-                    [Argo.schema| { "type": "object", "properties": { "bool": { "type": "boolean" }, "text": { "type": "string" } }, "required": [ "bool" ], "additionalProperties": true } |]
+                    Nothing
+                    [Argo.schema| { "type": "object", "properties": { "bool": { "$ref": "#/$defs/Bool" }, "text": { "$ref": "#/$defs/Text" } }, "required": [ "bool" ], "additionalProperties": true } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Record)
             Accum.evalAccumT actual mempty @?= Accum.evalAccumT expected mempty
         ]
@@ -1150,15 +1150,15 @@ main = Tasty.defaultMain $ Tasty.testGroup
           in
               [ Tasty.testCase "schema" $ do
                   let expected = schemafy
-                          Nothing  -- TODO
+                          Nothing
                           [Argo.schema|
                             {
                                 "type": "object",
                                 "properties": {
-                                    "t1c1f1": { "type": "number" },
-                                    "t1c1f2": { "oneOf": [ { "type": "number" }, { "type": "null" } ] },
-                                    "t1c1f3": { "type": "number" },
-                                    "t1c1f4": { "oneOf": [ { "type": "number" }, { "type": "null" } ] }
+                                    "t1c1f1": { "$ref": "#/$defs/Float" },
+                                    "t1c1f2": { "$ref": "#/$defs/Maybe Float" },
+                                    "t1c1f3": { "$ref": "#/$defs/Float" },
+                                    "t1c1f4": { "$ref": "#/$defs/Maybe Float" }
                                 },
                                 "required": [ "t1c1f1", "t1c1f2" ],
                                 "additionalProperties": true

--- a/source/test-suite/Main.hs
+++ b/source/test-suite/Main.hs
@@ -739,60 +739,60 @@ main = Tasty.defaultMain $ Tasty.testGroup
         [ Tasty.testCase "value" $ do
             let expected = schemafy (Just "Value") [Argo.schema| true |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Argo.Value)
-            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
+            Accum.evalAccumT actual mempty @?= Accum.evalAccumT expected mempty
         , Tasty.testCase "null" $ do
             let expected =
                     schemafy (Just "Null") [Argo.schema| { "type": "null" } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Null.Null)
-            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
+            Accum.evalAccumT actual mempty @?= Accum.evalAccumT expected mempty
         , Tasty.testCase "boolean" $ do
             let expected = schemafy
                     (Just "Boolean")
                     [Argo.schema| { "type": "boolean" } |]
                 actual =
                     Codec.schema (Argo.codec :: Codec.Value Boolean.Boolean)
-            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
+            Accum.evalAccumT actual mempty @?= Accum.evalAccumT expected mempty
         , Tasty.testCase "number" $ do
             let expected = schemafy
                     (Just "Number")
                     [Argo.schema| { "type": "number" } |]
                 actual =
                     Codec.schema (Argo.codec :: Codec.Value Number.Number)
-            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
+            Accum.evalAccumT actual mempty @?= Accum.evalAccumT expected mempty
         , Tasty.testCase "string" $ do
             let expected = schemafy
                     (Just "String")
                     [Argo.schema| { "type": "string" } |]
                 actual =
                     Codec.schema (Argo.codec :: Codec.Value String.String)
-            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
+            Accum.evalAccumT actual mempty @?= Accum.evalAccumT expected mempty
         , Tasty.testCase "array boolean" $ do
             let expected = schemafy
                     (Just "Array Boolean")
-                    [Argo.schema| { "type": "array", "items": { "type": "boolean" } } |]
+                    [Argo.schema| { "type": "array", "items": { "$ref": "#/$defs/Boolean" } } |]
                 actual =
                     Codec.schema
                         (Argo.codec :: Codec.Value
                               (Array.Array Boolean.Boolean)
                         )
-            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
+            Accum.evalAccumT actual mempty @?= Accum.evalAccumT expected mempty
         , Tasty.testCase "object boolean" $ do
             let expected = schemafy
                     (Just "Object Boolean")
-                    [Argo.schema| { "type": "object", "additionalProperties": { "type": "boolean" } } |]
+                    [Argo.schema| { "type": "object", "additionalProperties": { "$ref": "#/$defs/Boolean" } } |]
                 actual =
                     Codec.schema
                         (Argo.codec :: Codec.Value
                               (Object.Object Boolean.Boolean)
                         )
-            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
+            Accum.evalAccumT actual mempty @?= Accum.evalAccumT expected mempty
         , Tasty.testCase "maybe boolean" $ do
             let expected = schemafy
                     (Just "Maybe Boolean")
                     [Argo.schema| { "oneOf": [ { "type": "boolean" }, { "type": "null" } ] } |]
                 actual = Codec.schema
                     (Argo.codec :: Codec.Value (Maybe Boolean.Boolean))
-            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
+            Accum.evalAccumT actual mempty @?= Accum.evalAccumT expected mempty
         , Tasty.testCase "either boolean number" $ do
             let expected = schemafy
                     (Just "Either Boolean Number")
@@ -802,13 +802,13 @@ main = Tasty.defaultMain $ Tasty.testGroup
                         (Argo.codec :: Codec.Value
                               (Either Boolean.Boolean Number.Number)
                         )
-            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
+            Accum.evalAccumT actual mempty @?= Accum.evalAccumT expected mempty
         , Tasty.testCase "()" $ do
             let expected = schemafy
                     (Just "()")
                     [Argo.schema| { "type": "array", "items": [], "additionalItems": false } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value ())
-            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
+            Accum.evalAccumT actual mempty @?= Accum.evalAccumT expected mempty
         , Tasty.testCase "2-tuple" $ do
             let expected = schemafy
                     (Just "(Value,Null)")
@@ -818,7 +818,7 @@ main = Tasty.defaultMain $ Tasty.testGroup
                         ], "additionalItems": false } |]
                 actual = Codec.schema
                     (Argo.codec :: Codec.Value (Argo.Value, Null.Null))
-            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
+            Accum.evalAccumT actual mempty @?= Accum.evalAccumT expected mempty
         , Tasty.testCase "3-tuple" $ do
             let expected = schemafy
                     (Just "(Value,Null,Boolean)")
@@ -831,7 +831,7 @@ main = Tasty.defaultMain $ Tasty.testGroup
                     (Argo.codec :: Codec.Value
                           (Argo.Value, Null.Null, Boolean.Boolean)
                     )
-            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
+            Accum.evalAccumT actual mempty @?= Accum.evalAccumT expected mempty
         , Tasty.testCase "4-tuple" $ do
             let expected = schemafy
                     (Just "(Value,Null,Boolean,Number)")
@@ -849,7 +849,7 @@ main = Tasty.defaultMain $ Tasty.testGroup
                           , Number.Number
                           )
                     )
-            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
+            Accum.evalAccumT actual mempty @?= Accum.evalAccumT expected mempty
         , Tasty.testCase "5-tuple" $ do
             let expected = schemafy
                     (Just "(Value,Null,Boolean,Number,Integer)")
@@ -869,7 +869,7 @@ main = Tasty.defaultMain $ Tasty.testGroup
                           , Integer
                           )
                     )
-            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
+            Accum.evalAccumT actual mempty @?= Accum.evalAccumT expected mempty
         , Tasty.testCase "6-tuple" $ do
             let expected = schemafy
                     (Just "(Value,Null,Boolean,Number,Integer,String)")
@@ -891,7 +891,7 @@ main = Tasty.defaultMain $ Tasty.testGroup
                           , String.String
                           )
                     )
-            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
+            Accum.evalAccumT actual mempty @?= Accum.evalAccumT expected mempty
         , Tasty.testCase "7-tuple" $ do
             let expected = schemafy
                     (Just "(Value,Null,Boolean,Number,Integer,String,())")
@@ -915,7 +915,7 @@ main = Tasty.defaultMain $ Tasty.testGroup
                           , ()
                           )
                     )
-            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
+            Accum.evalAccumT actual mempty @?= Accum.evalAccumT expected mempty
         , Tasty.testCase "8-tuple" $ do
             let expected = schemafy
                     (Just "(Value,Null,Boolean,Number,Integer,String,(),Char)")
@@ -941,209 +941,209 @@ main = Tasty.defaultMain $ Tasty.testGroup
                           , Char
                           )
                     )
-            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
+            Accum.evalAccumT actual mempty @?= Accum.evalAccumT expected mempty
         , Tasty.testCase "bool" $ do
             let expected = schemafy
                     (Just "Bool")
                     [Argo.schema| { "type": "boolean" } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Bool)
-            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
+            Accum.evalAccumT actual mempty @?= Accum.evalAccumT expected mempty
         , Tasty.testCase "decimal" $ do
             let expected = schemafy
                     (Just "Decimal")
                     [Argo.schema| { "type": "number" } |]
                 actual =
                     Codec.schema (Argo.codec :: Codec.Value Decimal.Decimal)
-            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
+            Accum.evalAccumT actual mempty @?= Accum.evalAccumT expected mempty
         , Tasty.testCase "text" $ do
             let expected = schemafy
                     (Just "Text")
                     [Argo.schema| { "type": "string" } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Text.Text)
-            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
+            Accum.evalAccumT actual mempty @?= Accum.evalAccumT expected mempty
         , Tasty.testCase "list boolean" $ do
             let expected = schemafy
                     (Just "[Boolean]")
-                    [Argo.schema| { "type": "array", "items": { "type": "boolean" } } |]
+                    [Argo.schema| { "type": "array", "items": { "$ref": "#/$defs/Boolean" } } |]
                 actual =
                     Codec.schema (Argo.codec :: Codec.Value [Boolean.Boolean])
-            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
+            Accum.evalAccumT actual mempty @?= Accum.evalAccumT expected mempty
         , Tasty.testCase "map name boolean" $ do
             let expected = schemafy
                     (Just "Map Name Boolean")
-                    [Argo.schema| { "type": "object", "additionalProperties": { "type": "boolean" } } |]
+                    [Argo.schema| { "type": "object", "additionalProperties": { "$ref": "#/$defs/Boolean" } } |]
                 actual =
                     Codec.schema
                         (Argo.codec :: Codec.Value
                               (Map.Map Name.Name Boolean.Boolean)
                         )
-            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
+            Accum.evalAccumT actual mempty @?= Accum.evalAccumT expected mempty
         , Tasty.testCase "map (argo) string boolean" $ do
             let expected = schemafy
                     (Just "Map String Boolean")
-                    [Argo.schema| { "type": "object", "additionalProperties": { "type": "boolean" } } |]
+                    [Argo.schema| { "type": "object", "additionalProperties": { "$ref": "#/$defs/Boolean" } } |]
                 actual = Codec.schema
                     (Argo.codec :: Codec.Value
                           (Map.Map String.String Boolean.Boolean)
                     )
-            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
+            Accum.evalAccumT actual mempty @?= Accum.evalAccumT expected mempty
         , Tasty.testCase "map (strict) text boolean" $ do
             let expected = schemafy
                     (Just "Map Text Boolean")
-                    [Argo.schema| { "type": "object", "additionalProperties": { "type": "boolean" } } |]
+                    [Argo.schema| { "type": "object", "additionalProperties": { "$ref": "#/$defs/Boolean" } } |]
                 actual =
                     Codec.schema
                         (Argo.codec :: Codec.Value
                               (Map.Map Text.Text Boolean.Boolean)
                         )
-            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
+            Accum.evalAccumT actual mempty @?= Accum.evalAccumT expected mempty
         , Tasty.testCase "map (lazy) text boolean" $ do
             let expected = schemafy
                     (Just "Map Text Boolean")
-                    [Argo.schema| { "type": "object", "additionalProperties": { "type": "boolean" } } |]
+                    [Argo.schema| { "type": "object", "additionalProperties": { "$ref": "#/$defs/Boolean" } } |]
                 actual = Codec.schema
                     (Argo.codec :: Codec.Value
                           (Map.Map LazyText.Text Boolean.Boolean)
                     )
-            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
+            Accum.evalAccumT actual mempty @?= Accum.evalAccumT expected mempty
         , Tasty.testCase "map (base) string boolean" $ do
             let expected = schemafy
                     (Just "Map [Char] Boolean")
-                    [Argo.schema| { "type": "object", "additionalProperties": { "type": "boolean" } } |]
+                    [Argo.schema| { "type": "object", "additionalProperties": { "$ref": "#/$defs/Boolean" } } |]
                 actual =
                     Codec.schema
                         (Argo.codec :: Codec.Value
                               (Map.Map String Boolean.Boolean)
                         )
-            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
+            Accum.evalAccumT actual mempty @?= Accum.evalAccumT expected mempty
         , Tasty.testCase "string" $ do
             let expected = schemafy
                     (Just "[Char]")
                     [Argo.schema| { "type": "string" } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value String)
-            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
+            Accum.evalAccumT actual mempty @?= Accum.evalAccumT expected mempty
         , Tasty.testCase "char" $ do
             let expected = schemafy
                     (Just "Char")
                     [Argo.schema| { "type": "string", "minLength": 1, "maxLength": 1 } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Char)
-            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
+            Accum.evalAccumT actual mempty @?= Accum.evalAccumT expected mempty
         , Tasty.testCase "lazy text" $ do
             let expected = schemafy
                     (Just "Text")
                     [Argo.schema| { "type": "string" } |]
                 actual =
                     Codec.schema (Argo.codec :: Codec.Value LazyText.Text)
-            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
+            Accum.evalAccumT actual mempty @?= Accum.evalAccumT expected mempty
         , Tasty.testCase "non-empty boolean" $ do
             let expected = schemafy
                     (Just "NonEmpty Boolean")
                     [Argo.schema| { "type": "array", "items": { "type": "boolean" }, "minItems": 1 } |]
                 actual = Codec.schema
                     (Argo.codec :: Codec.Value (NonEmpty Boolean.Boolean))
-            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
+            Accum.evalAccumT actual mempty @?= Accum.evalAccumT expected mempty
         , Tasty.testCase "integer" $ do
             let expected = schemafy
                     (Just "Integer")
                     [Argo.schema| { "type": "integer" } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Integer)
-            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
+            Accum.evalAccumT actual mempty @?= Accum.evalAccumT expected mempty
         , Tasty.testCase "int" $ do
             let expected = schemafy
                     (Just "Int")
                     [Argo.schema| { "type": "integer", "minimum": -9223372036854775808, "maximum": 9223372036854775807 } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Int)
-            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
+            Accum.evalAccumT actual mempty @?= Accum.evalAccumT expected mempty
         , Tasty.testCase "int8" $ do
             let expected = schemafy
                     (Just "Int8")
                     [Argo.schema| { "type": "integer", "minimum": -128, "maximum": 127 } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Int.Int8)
-            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
+            Accum.evalAccumT actual mempty @?= Accum.evalAccumT expected mempty
         , Tasty.testCase "int16" $ do
             let expected = schemafy
                     (Just "Int16")
                     [Argo.schema| { "type": "integer", "minimum": -32768, "maximum": 32767 } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Int.Int16)
-            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
+            Accum.evalAccumT actual mempty @?= Accum.evalAccumT expected mempty
         , Tasty.testCase "int32" $ do
             let expected = schemafy
                     (Just "Int32")
                     [Argo.schema| { "type": "integer", "minimum": -2147483648, "maximum": 2147483647 } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Int.Int32)
-            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
+            Accum.evalAccumT actual mempty @?= Accum.evalAccumT expected mempty
         , Tasty.testCase "int64" $ do
             let expected = schemafy
                     (Just "Int64")
                     [Argo.schema| { "type": "integer", "minimum": -9223372036854775808, "maximum": 9223372036854775807 } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Int.Int64)
-            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
+            Accum.evalAccumT actual mempty @?= Accum.evalAccumT expected mempty
         , Tasty.testCase "natural" $ do
             let expected = schemafy
                     (Just "Natural")
                     [Argo.schema| { "type": "integer", "minimum": 0 } |]
                 actual =
                     Codec.schema (Argo.codec :: Codec.Value Natural.Natural)
-            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
+            Accum.evalAccumT actual mempty @?= Accum.evalAccumT expected mempty
         , Tasty.testCase "word" $ do
             let expected = schemafy
                     (Just "Word")
                     [Argo.schema| { "type": "integer", "minimum": 0, "maximum": 18446744073709551615 } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Word)
-            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
+            Accum.evalAccumT actual mempty @?= Accum.evalAccumT expected mempty
         , Tasty.testCase "word8" $ do
             let expected = schemafy
                     (Just "Word8")
                     [Argo.schema| { "type": "integer", "minimum": 0, "maximum": 255 } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Word.Word8)
-            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
+            Accum.evalAccumT actual mempty @?= Accum.evalAccumT expected mempty
         , Tasty.testCase "word16" $ do
             let expected = schemafy
                     (Just "Word16")
                     [Argo.schema| { "type": "integer", "minimum": 0, "maximum": 65535 } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Word.Word16)
-            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
+            Accum.evalAccumT actual mempty @?= Accum.evalAccumT expected mempty
         , Tasty.testCase "word32" $ do
             let expected = schemafy
                     (Just "Word32")
                     [Argo.schema| { "type": "integer", "minimum": 0, "maximum": 4294967295 } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Word.Word32)
-            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
+            Accum.evalAccumT actual mempty @?= Accum.evalAccumT expected mempty
         , Tasty.testCase "word64" $ do
             let expected = schemafy
                     (Just "Word64")
                     [Argo.schema| { "type": "integer", "minimum": 0, "maximum": 18446744073709551615 } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Word.Word64)
-            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
+            Accum.evalAccumT actual mempty @?= Accum.evalAccumT expected mempty
         , Tasty.testCase "float" $ do
             let expected = schemafy
                     (Just "Float")
                     [Argo.schema| { "type": "number" } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Float)
-            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
+            Accum.evalAccumT actual mempty @?= Accum.evalAccumT expected mempty
         , Tasty.testCase "double" $ do
             let expected = schemafy
                     (Just "Double")
                     [Argo.schema| { "type": "number" } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Double)
-            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
+            Accum.evalAccumT actual mempty @?= Accum.evalAccumT expected mempty
         , Tasty.testCase "pointer" $ do
             let expected = schemafy
                     (Just "Pointer")
                     [Argo.schema| { "type": "string" } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Argo.Pointer)
-            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
+            Accum.evalAccumT actual mempty @?= Accum.evalAccumT expected mempty
         , Tasty.testCase "schema" $ do
             let expected = schemafy (Just "Schema") [Argo.schema| true |]
                 actual =
                     Codec.schema (Argo.codec :: Codec.Value Schema.Schema)
-            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
+            Accum.evalAccumT actual mempty @?= Accum.evalAccumT expected mempty
         , Tasty.testCase "record" $ do
             let expected = schemafy
                     Nothing  -- TODO
                     [Argo.schema| { "type": "object", "properties": { "bool": { "type": "boolean" }, "text": { "type": "string" } }, "required": [ "bool" ], "additionalProperties": true } |]
                 actual = Codec.schema (Argo.codec :: Codec.Value Record)
-            Accum.runAccum actual mempty @?= Accum.runAccum expected mempty
+            Accum.evalAccumT actual mempty @?= Accum.evalAccumT expected mempty
         ]
     , Tasty.testGroup "T1"
         $ let codec = Argo.codec :: Codec.Value T1
@@ -1165,8 +1165,8 @@ main = Tasty.defaultMain $ Tasty.testGroup
                             }
                         |]
                       actual = Codec.schema codec
-                  Accum.runAccum actual mempty
-                      @?= Accum.runAccum expected mempty
+                  Accum.evalAccumT actual mempty
+                      @?= Accum.evalAccumT expected mempty
               , Tasty.testCase "decode" $ do
                   hush (Argo.decode "{ \"t1c1f1\": 0 }")
                       @?= (Nothing :: Maybe T1)


### PR DESCRIPTION
This will fix #46.

Still to do:

- Switch from `Identity` to `Accum`. 
- Figure out how to implement `Applicative` and `Alternative` instances for `Codec`. 
- Remove `Semigroup` instance for `Identifier`.
- Add `Identifier` to most (if not all) schemas.
- Potentially introduce a custom type for schemas like this: `data IdentifiedSchema = Anonymous Schema | Identified Identifier Schema`.