### PR TITLE
Improve handling of optional and nullable fields

### DIFF
--- a/argo.cabal
+++ b/argo.cabal
@@ -98,6 +98,8 @@ library
         Argo.Type.Encoder
         Argo.Type.Flag
         Argo.Type.Indent
+        Argo.Type.Nullable
+        Argo.Type.Optional
         Argo.Type.Permission
         Argo.Type.Settings
     hs-source-dirs: source/library

--- a/source/library/Argo/Class/HasCodec.hs
+++ b/source/library/Argo/Class/HasCodec.hs
@@ -522,14 +522,11 @@ optionalNullable
     -> Codec.Value a
     -> Codec.Object (Maybe a)
 optionalNullable k =
-    let
-        f :: Optional.Optional (Nullable.Nullable b) -> Maybe b
-        f = maybe Nothing Nullable.toMaybe . Optional.toMaybe
-        g :: Maybe b -> Optional.Optional (Nullable.Nullable b)
-        g x = Optional.fromMaybe $ case x of
-            Nothing -> Nothing
-            Just y -> Just . Nullable.fromMaybe $ Just y
-    in Codec.map f g . Codec.optional k . nullable
+    Codec.map
+            (maybe Nothing Nullable.toMaybe . Optional.toMaybe)
+            (Optional.fromMaybe . fmap (Nullable.fromMaybe . Just))
+        . Codec.optional k
+        . nullable
 
 nullable
     :: Typeable.Typeable a

--- a/source/library/Argo/Class/HasCodec.hs
+++ b/source/library/Argo/Class/HasCodec.hs
@@ -524,7 +524,7 @@ optionalNullable
 optionalNullable k =
     Codec.map
             (maybe Nothing Nullable.toMaybe . Optional.toMaybe)
-            (Optional.fromMaybe . fmap (Nullable.fromMaybe . Just))
+            (Optional.fromMaybe . fmap Nullable.just)
         . Codec.optional k
         . nullable
 
@@ -534,8 +534,5 @@ nullable
     -> Codec.Value (Nullable.Nullable a)
 nullable c =
     Codec.identified
-        $ Codec.mapMaybe (Just . Nullable.fromMaybe . Just) Nullable.toMaybe c
-        <|> Codec.map
-                (const $ Nullable.fromMaybe Nothing)
-                (const $ Null.fromUnit ())
-                codec
+        $ Codec.mapMaybe (Just . Nullable.just) Nullable.toMaybe c
+        <|> Codec.map (const Nullable.nothing) (const $ Null.fromUnit ()) codec

--- a/source/library/Argo/Codec/Object.hs
+++ b/source/library/Argo/Codec/Object.hs
@@ -56,7 +56,7 @@ required k c = Codec.Codec
                     <> show k
             Just x -> pure x
     , Codec.encode = \x -> do
-        Monad.void . Codec.encode (optional k c) . Optional.fromMaybe $ Just x
+        Monad.void . Codec.encode (optional k c) $ Optional.just x
         pure x
     , Codec.schema =
         pure
@@ -75,8 +75,8 @@ optional k c = Codec.Codec
                 Left y -> Trans.lift $ Trans.throwE y
                 Right y -> do
                     Trans.put ys
-                    pure . Optional.fromMaybe $ Just y
-            _ -> pure $ Optional.fromMaybe Nothing
+                    pure $ Optional.just y
+            _ -> pure Optional.nothing
     , Codec.encode = \x -> do
         case Optional.toMaybe x of
             Nothing -> pure ()

--- a/source/library/Argo/Type/Nullable.hs
+++ b/source/library/Argo/Type/Nullable.hs
@@ -1,0 +1,11 @@
+module Argo.Type.Nullable where
+
+newtype Nullable a
+    = Nullable (Maybe a)
+    deriving (Eq, Show)
+
+fromMaybe :: Maybe a -> Nullable a
+fromMaybe = Nullable
+
+toMaybe :: Nullable a -> Maybe a
+toMaybe (Nullable x) = x

--- a/source/library/Argo/Type/Nullable.hs
+++ b/source/library/Argo/Type/Nullable.hs
@@ -9,3 +9,9 @@ fromMaybe = Nullable
 
 toMaybe :: Nullable a -> Maybe a
 toMaybe (Nullable x) = x
+
+nothing :: Nullable a
+nothing = fromMaybe Nothing
+
+just :: a -> Nullable a
+just = fromMaybe . Just

--- a/source/library/Argo/Type/Optional.hs
+++ b/source/library/Argo/Type/Optional.hs
@@ -9,3 +9,9 @@ fromMaybe = Optional
 
 toMaybe :: Optional a -> Maybe a
 toMaybe (Optional x) = x
+
+nothing :: Optional a
+nothing = fromMaybe Nothing
+
+just :: a -> Optional a
+just = fromMaybe . Just

--- a/source/library/Argo/Type/Optional.hs
+++ b/source/library/Argo/Type/Optional.hs
@@ -1,0 +1,11 @@
+module Argo.Type.Optional where
+
+newtype Optional a
+    = Optional (Maybe a)
+    deriving (Eq, Show)
+
+fromMaybe :: Maybe a -> Optional a
+fromMaybe = Optional
+
+toMaybe :: Optional a -> Maybe a
+toMaybe (Optional x) = x

--- a/source/test-suite/Main.hs
+++ b/source/test-suite/Main.hs
@@ -631,14 +631,10 @@ main = Tasty.defaultMain $ Tasty.testGroup
                     (Argo.Array [Argo.String "", Argo.Boolean False])
                 @?= Right ("" :: Text.Text, False)
         , Tasty.testCase "encode record" $ do
-            Codec.encodeWith
-                    Argo.codec
-                    (Record False $ Optional.fromMaybe Nothing)
+            Codec.encodeWith Argo.codec (Record False Optional.nothing)
                 @?= Argo.Object
                         [Argo.Member (Argo.Name "bool") $ Argo.Boolean False]
-            Codec.encodeWith
-                    Argo.codec
-                    (Record False . Optional.fromMaybe $ Just "")
+            Codec.encodeWith Argo.codec (Record False $ Optional.just "")
                 @?= Argo.Object
                         [ Argo.Member (Argo.Name "bool") $ Argo.Boolean False
                         , Argo.Member (Argo.Name "text") $ Argo.String ""
@@ -649,7 +645,7 @@ main = Tasty.defaultMain $ Tasty.testGroup
                     (Argo.Object
                         [Argo.Member (Argo.Name "bool") $ Argo.Boolean False]
                     )
-                @?= Right (Record False $ Optional.fromMaybe Nothing)
+                @?= Right (Record False Optional.nothing)
             Codec.decodeWith
                     Argo.codec
                     (Argo.Object
@@ -657,7 +653,7 @@ main = Tasty.defaultMain $ Tasty.testGroup
                         , Argo.Member (Argo.Name "text") $ Argo.String ""
                         ]
                     )
-                @?= Right (Record False . Optional.fromMaybe $ Just "")
+                @?= Right (Record False $ Optional.just "")
         ]
     , Tasty.testGroup "Pointer"
         $ let pointer = Argo.Pointer . fmap Argo.Token
@@ -1272,20 +1268,22 @@ main = Tasty.defaultMain $ Tasty.testGroup
               , Tasty.testCase "decode" $ do
                   hush (Argo.decode "{ \"t1c1f1\": 0 }")
                       @?= (Nothing :: Maybe T1)
-                  Argo.decode "{ \"t1c1f1\": 0, \"t1c1f2\": null }" @?= Right
-                      (T1C1
-                          0
-                          Nullable.nothing
-                          (Optional.fromMaybe Nothing)
-                          (Optional.fromMaybe Nothing)
-                      )
-                  Argo.decode "{ \"t1c1f1\": 1, \"t1c1f2\": 0 }" @?= Right
-                      (T1C1
-                          1
-                          (Nullable.just 0)
-                          (Optional.fromMaybe Nothing)
-                          (Optional.fromMaybe Nothing)
-                      )
+                  Argo.decode "{ \"t1c1f1\": 0, \"t1c1f2\": null }"
+                      @?= Right
+                              (T1C1
+                                  0
+                                  Nullable.nothing
+                                  Optional.nothing
+                                  Optional.nothing
+                              )
+                  Argo.decode "{ \"t1c1f1\": 1, \"t1c1f2\": 0 }"
+                      @?= Right
+                              (T1C1
+                                  1
+                                  (Nullable.just 0)
+                                  Optional.nothing
+                                  Optional.nothing
+                              )
                   hush
                           (Argo.decode
                               "{ \"t1c1f1\": 2, \"t1c1f2\": null, \"t1c1f3\": null }"
@@ -1297,8 +1295,8 @@ main = Tasty.defaultMain $ Tasty.testGroup
                               (T1C1
                                   3
                                   Nullable.nothing
-                                  (Optional.fromMaybe $ Just 0)
-                                  (Optional.fromMaybe Nothing)
+                                  (Optional.just 0)
+                                  Optional.nothing
                               )
                   Argo.decode
                           "{ \"t1c1f1\": 4, \"t1c1f2\": null, \"t1c1f4\": null }"
@@ -1306,9 +1304,8 @@ main = Tasty.defaultMain $ Tasty.testGroup
                               (T1C1
                                   4
                                   Nullable.nothing
-                                  (Optional.fromMaybe Nothing)
-                                  (Optional.fromMaybe . Just $ Nullable.nothing
-                                  )
+                                  Optional.nothing
+                                  (Optional.just Nullable.nothing)
                               )
                   Argo.decode
                           "{ \"t1c1f1\": 5, \"t1c1f2\": null, \"t1c1f4\": 0 }"
@@ -1316,12 +1313,8 @@ main = Tasty.defaultMain $ Tasty.testGroup
                               (T1C1
                                   5
                                   Nullable.nothing
-                                  (Optional.fromMaybe Nothing)
-                                  (Optional.fromMaybe
-                                  . Just
-                                  . Nullable.fromMaybe
-                                  $ Just 0
-                                  )
+                                  Optional.nothing
+                                  (Optional.just . Nullable.fromMaybe $ Just 0)
                               )
                   hush (Argo.decode "{ \"t1c1f1\": 6, \"t1c1f2\": [] }")
                       @?= (Nothing :: Maybe T1)
@@ -1344,40 +1337,40 @@ main = Tasty.defaultMain $ Tasty.testGroup
                           (T1C1
                               0
                               Nullable.nothing
-                              (Optional.fromMaybe Nothing)
-                              (Optional.fromMaybe Nothing)
+                              Optional.nothing
+                              Optional.nothing
                           )
                       @?= "{\"t1c1f1\":0,\"t1c1f2\":null}"
                   encode
                           (T1C1
                               1
                               (Nullable.just 0)
-                              (Optional.fromMaybe Nothing)
-                              (Optional.fromMaybe Nothing)
+                              Optional.nothing
+                              Optional.nothing
                           )
                       @?= "{\"t1c1f1\":1,\"t1c1f2\":0}"
                   encode
                           (T1C1
                               2
                               Nullable.nothing
-                              (Optional.fromMaybe $ Just 0)
-                              (Optional.fromMaybe Nothing)
+                              (Optional.just 0)
+                              Optional.nothing
                           )
                       @?= "{\"t1c1f1\":2,\"t1c1f2\":null,\"t1c1f3\":0}"
                   encode
                           (T1C1
                               3
                               Nullable.nothing
-                              (Optional.fromMaybe Nothing)
-                              (Optional.fromMaybe $ Just Nullable.nothing)
+                              Optional.nothing
+                              (Optional.just Nullable.nothing)
                           )
                       @?= "{\"t1c1f1\":3,\"t1c1f2\":null,\"t1c1f4\":null}"
                   encode
                           (T1C1
                               4
                               Nullable.nothing
-                              (Optional.fromMaybe Nothing)
-                              (Optional.fromMaybe . Just $ Nullable.just 0)
+                              Optional.nothing
+                              (Optional.just $ Nullable.just 0)
                           )
                       @?= "{\"t1c1f1\":4,\"t1c1f2\":null,\"t1c1f4\":0}"
               ]

--- a/source/test-suite/Main.hs
+++ b/source/test-suite/Main.hs
@@ -1275,14 +1275,14 @@ main = Tasty.defaultMain $ Tasty.testGroup
                   Argo.decode "{ \"t1c1f1\": 0, \"t1c1f2\": null }" @?= Right
                       (T1C1
                           0
-                          (Nullable.fromMaybe Nothing)
+                          Nullable.nothing
                           (Optional.fromMaybe Nothing)
                           (Optional.fromMaybe Nothing)
                       )
                   Argo.decode "{ \"t1c1f1\": 1, \"t1c1f2\": 0 }" @?= Right
                       (T1C1
                           1
-                          (Nullable.fromMaybe $ Just 0)
+                          (Nullable.just 0)
                           (Optional.fromMaybe Nothing)
                           (Optional.fromMaybe Nothing)
                       )
@@ -1296,7 +1296,7 @@ main = Tasty.defaultMain $ Tasty.testGroup
                       @?= Right
                               (T1C1
                                   3
-                                  (Nullable.fromMaybe Nothing)
+                                  Nullable.nothing
                                   (Optional.fromMaybe $ Just 0)
                                   (Optional.fromMaybe Nothing)
                               )
@@ -1305,11 +1305,9 @@ main = Tasty.defaultMain $ Tasty.testGroup
                       @?= Right
                               (T1C1
                                   4
-                                  (Nullable.fromMaybe Nothing)
+                                  Nullable.nothing
                                   (Optional.fromMaybe Nothing)
-                                  (Optional.fromMaybe
-                                  . Just
-                                  $ Nullable.fromMaybe Nothing
+                                  (Optional.fromMaybe . Just $ Nullable.nothing
                                   )
                               )
                   Argo.decode
@@ -1317,7 +1315,7 @@ main = Tasty.defaultMain $ Tasty.testGroup
                       @?= Right
                               (T1C1
                                   5
-                                  (Nullable.fromMaybe Nothing)
+                                  Nullable.nothing
                                   (Optional.fromMaybe Nothing)
                                   (Optional.fromMaybe
                                   . Just
@@ -1345,7 +1343,7 @@ main = Tasty.defaultMain $ Tasty.testGroup
                   encode
                           (T1C1
                               0
-                              (Nullable.fromMaybe Nothing)
+                              Nullable.nothing
                               (Optional.fromMaybe Nothing)
                               (Optional.fromMaybe Nothing)
                           )
@@ -1353,7 +1351,7 @@ main = Tasty.defaultMain $ Tasty.testGroup
                   encode
                           (T1C1
                               1
-                              (Nullable.fromMaybe $ Just 0)
+                              (Nullable.just 0)
                               (Optional.fromMaybe Nothing)
                               (Optional.fromMaybe Nothing)
                           )
@@ -1361,7 +1359,7 @@ main = Tasty.defaultMain $ Tasty.testGroup
                   encode
                           (T1C1
                               2
-                              (Nullable.fromMaybe Nothing)
+                              Nullable.nothing
                               (Optional.fromMaybe $ Just 0)
                               (Optional.fromMaybe Nothing)
                           )
@@ -1369,23 +1367,17 @@ main = Tasty.defaultMain $ Tasty.testGroup
                   encode
                           (T1C1
                               3
-                              (Nullable.fromMaybe Nothing)
+                              Nullable.nothing
                               (Optional.fromMaybe Nothing)
-                              (Optional.fromMaybe . Just $ Nullable.fromMaybe
-                                  Nothing
-                              )
+                              (Optional.fromMaybe $ Just Nullable.nothing)
                           )
                       @?= "{\"t1c1f1\":3,\"t1c1f2\":null,\"t1c1f4\":null}"
                   encode
                           (T1C1
                               4
-                              (Nullable.fromMaybe Nothing)
+                              Nullable.nothing
                               (Optional.fromMaybe Nothing)
-                              (Optional.fromMaybe
-                              . Just
-                              . Nullable.fromMaybe
-                              $ Just 0
-                              )
+                              (Optional.fromMaybe . Just $ Nullable.just 0)
                           )
                       @?= "{\"t1c1f1\":4,\"t1c1f2\":null,\"t1c1f4\":0}"
               ]

--- a/source/test-suite/Main.hs
+++ b/source/test-suite/Main.hs
@@ -1314,7 +1314,7 @@ main = Tasty.defaultMain $ Tasty.testGroup
                                   5
                                   Nullable.nothing
                                   Optional.nothing
-                                  (Optional.just . Nullable.fromMaybe $ Just 0)
+                                  (Optional.just $ Nullable.just 0)
                               )
                   hush (Argo.decode "{ \"t1c1f1\": 6, \"t1c1f2\": [] }")
                       @?= (Nothing :: Maybe T1)


### PR DESCRIPTION
Fixes #60. This is an improvement for correctness, but it's not good for ergonomics. To get the previous behavior of `newtype T = C { f :: Maybe X }` you have to do `newtype T = C { f :: Optional (Nullable X) }`, which is pretty wordy. I like having the ability to be that precise, but in typical use `Maybe a` should be treated like `Optional (Nullable a)`