### PR TITLE
Define `NFData` instances manually, remove `Generic` instances

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,6 +7,7 @@
     ],
     "postCreateCommand": "cabal update",
     "settings": {
-        "haskell.formattingProvider": "brittany"
+        "haskell.formattingProvider": "brittany",
+        "editor.formatOnSave": true
     }
 }

--- a/source/library/Argo/Internal/Json/Array.hs
+++ b/source/library/Argo/Internal/Json/Array.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DeriveLift #-}
 
 module Argo.Internal.Json.Array where
@@ -11,11 +9,13 @@ import qualified Argo.Vendor.Builder as Builder
 import qualified Argo.Vendor.DeepSeq as DeepSeq
 import qualified Argo.Vendor.TemplateHaskell as TH
 import qualified Argo.Vendor.Transformers as Trans
-import qualified GHC.Generics as Generics
 
 newtype Array value
     = Array [value]
-    deriving (Eq, Generics.Generic, TH.Lift, DeepSeq.NFData, Show)
+    deriving (Eq, TH.Lift, Show)
+
+instance DeepSeq.NFData value => DeepSeq.NFData (Array value) where
+    rnf = DeepSeq.rnf . toList
 
 fromList :: [value] -> Array value
 fromList = Array

--- a/source/library/Argo/Internal/Json/Boolean.hs
+++ b/source/library/Argo/Internal/Json/Boolean.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DeriveLift #-}
 
 module Argo.Internal.Json.Boolean where
@@ -13,11 +11,13 @@ import qualified Argo.Vendor.Builder as Builder
 import qualified Argo.Vendor.DeepSeq as DeepSeq
 import qualified Argo.Vendor.TemplateHaskell as TH
 import qualified Argo.Vendor.Transformers as Trans
-import qualified GHC.Generics as Generics
 
 newtype Boolean
     = Boolean Bool
-    deriving (Eq, Generics.Generic, TH.Lift, DeepSeq.NFData, Show)
+    deriving (Eq, TH.Lift, Show)
+
+instance DeepSeq.NFData Boolean where
+    rnf = DeepSeq.rnf . toBool
 
 fromBool :: Bool -> Boolean
 fromBool = Boolean

--- a/source/library/Argo/Internal/Json/Member.hs
+++ b/source/library/Argo/Internal/Json/Member.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DeriveLift #-}
 
 module Argo.Internal.Json.Member where
@@ -14,10 +12,12 @@ import qualified Argo.Vendor.DeepSeq as DeepSeq
 import qualified Argo.Vendor.TemplateHaskell as TH
 import qualified Argo.Vendor.Transformers as Trans
 import qualified Control.Monad as Monad
-import qualified GHC.Generics as Generics
 
 data Member value = Member Name.Name value
-    deriving (Eq, Generics.Generic, TH.Lift, DeepSeq.NFData, Show)
+    deriving (Eq, TH.Lift, Show)
+
+instance DeepSeq.NFData value => DeepSeq.NFData (Member value) where
+    rnf = DeepSeq.rnf . toTuple
 
 fromTuple :: (Name.Name, value) -> Member value
 fromTuple = uncurry Member

--- a/source/library/Argo/Internal/Json/Name.hs
+++ b/source/library/Argo/Internal/Json/Name.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DeriveLift #-}
 
 module Argo.Internal.Json.Name where
@@ -10,11 +8,13 @@ import qualified Argo.Internal.Type.Encoder as Encoder
 import qualified Argo.Vendor.DeepSeq as DeepSeq
 import qualified Argo.Vendor.TemplateHaskell as TH
 import qualified Data.String
-import qualified GHC.Generics as Generics
 
 newtype Name
     = Name String.String
-    deriving (Eq, Generics.Generic, TH.Lift, DeepSeq.NFData, Ord, Show)
+    deriving (Eq, TH.Lift, Ord, Show)
+
+instance DeepSeq.NFData Name where
+    rnf = DeepSeq.rnf . toString
 
 instance Data.String.IsString Name where
     fromString = fromString . Data.String.fromString

--- a/source/library/Argo/Internal/Json/Null.hs
+++ b/source/library/Argo/Internal/Json/Null.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DeriveLift #-}
 
 module Argo.Internal.Json.Null where
@@ -11,11 +9,13 @@ import qualified Argo.Vendor.Builder as Builder
 import qualified Argo.Vendor.DeepSeq as DeepSeq
 import qualified Argo.Vendor.TemplateHaskell as TH
 import qualified Argo.Vendor.Transformers as Trans
-import qualified GHC.Generics as Generics
 
 newtype Null
     = Null ()
-    deriving (Eq, Generics.Generic, TH.Lift, DeepSeq.NFData, Show)
+    deriving (Eq, TH.Lift, Show)
+
+instance DeepSeq.NFData Null where
+    rnf = DeepSeq.rnf . toUnit
 
 fromUnit :: () -> Null
 fromUnit = Null

--- a/source/library/Argo/Internal/Json/Number.hs
+++ b/source/library/Argo/Internal/Json/Number.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DeriveLift #-}
 
 module Argo.Internal.Json.Number where
@@ -18,11 +16,13 @@ import qualified Control.Monad as Monad
 import qualified Data.Bool as Bool
 import qualified Data.Maybe as Maybe
 import qualified Data.Word as Word
-import qualified GHC.Generics as Generics
 
 newtype Number
     = Number Decimal.Decimal
-    deriving (Eq, Generics.Generic, TH.Lift, DeepSeq.NFData, Show)
+    deriving (Eq, TH.Lift, Show)
+
+instance DeepSeq.NFData Number where
+    rnf = DeepSeq.rnf . toDecimal
 
 fromDecimal :: Decimal.Decimal -> Number
 fromDecimal = Number

--- a/source/library/Argo/Internal/Json/Object.hs
+++ b/source/library/Argo/Internal/Json/Object.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DeriveLift #-}
 
 module Argo.Internal.Json.Object where
@@ -13,11 +11,13 @@ import qualified Argo.Vendor.DeepSeq as DeepSeq
 import qualified Argo.Vendor.TemplateHaskell as TH
 import qualified Argo.Vendor.Transformers as Trans
 import qualified Control.Monad as Monad
-import qualified GHC.Generics as Generics
 
 newtype Object value
     = Object [Member.Member value]
-    deriving (Eq, Generics.Generic, TH.Lift, DeepSeq.NFData, Show)
+    deriving (Eq, TH.Lift, Show)
+
+instance DeepSeq.NFData value => DeepSeq.NFData (Object value) where
+    rnf = DeepSeq.rnf . toList
 
 fromList :: [Member.Member value] -> Object value
 fromList = Object

--- a/source/library/Argo/Internal/Json/String.hs
+++ b/source/library/Argo/Internal/Json/String.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DeriveLift #-}
 
 module Argo.Internal.Json.String where
@@ -17,11 +15,13 @@ import qualified Control.Monad as Monad
 import qualified Data.Char as Char
 import qualified Data.String as String
 import qualified Data.Word as Word
-import qualified GHC.Generics as Generics
 
 newtype String
     = String Text.Text
-    deriving (Eq, Generics.Generic, TH.Lift, DeepSeq.NFData, Ord, Show)
+    deriving (Eq, TH.Lift, Ord, Show)
+
+instance DeepSeq.NFData Argo.Internal.Json.String.String where
+    rnf = DeepSeq.rnf . toText
 
 instance String.IsString Argo.Internal.Json.String.String where
     fromString = fromText . String.fromString

--- a/source/library/Argo/Internal/Json/Value.hs
+++ b/source/library/Argo/Internal/Json/Value.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DeriveLift #-}
 
 module Argo.Internal.Json.Value where
@@ -17,7 +15,6 @@ import qualified Argo.Internal.Type.Encoder as Encoder
 import qualified Argo.Vendor.DeepSeq as DeepSeq
 import qualified Argo.Vendor.TemplateHaskell as TH
 import qualified Data.String
-import qualified GHC.Generics as Generics
 
 -- | A JSON (JavaScript Object Notation) value, as described by RFC 8259.
 -- <https://datatracker.ietf.org/doc/html/rfc8259>
@@ -28,7 +25,16 @@ data Value
     | String String.String
     | Array (Array.Array Value)
     | Object (Object.Object Value)
-    deriving (Eq, Generics.Generic, TH.Lift, DeepSeq.NFData, Show)
+    deriving (Eq, TH.Lift, Show)
+
+instance DeepSeq.NFData Value where
+    rnf x = case x of
+        Null y -> DeepSeq.rnf y
+        Boolean y -> DeepSeq.rnf y
+        Number y -> DeepSeq.rnf y
+        String y -> DeepSeq.rnf y
+        Array y -> DeepSeq.rnf y
+        Object y -> DeepSeq.rnf y
 
 instance Data.String.IsString Value where
     fromString = String . Data.String.fromString

--- a/source/library/Argo/Internal/Pointer/Pointer.hs
+++ b/source/library/Argo/Internal/Pointer/Pointer.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DeriveLift #-}
 
 module Argo.Internal.Pointer.Pointer where
@@ -21,14 +19,16 @@ import qualified Argo.Vendor.Text as Text
 import qualified Argo.Vendor.Transformers as Trans
 import qualified Control.Applicative as Applicative
 import qualified Data.List as List
-import qualified GHC.Generics as Generics
 import qualified Text.Read as Read
 
 -- | A JSON pointer, as described by RFC 6901.
 -- <https://datatracker.ietf.org/doc/html/rfc6901>
 newtype Pointer
     = Pointer [Token.Token]
-    deriving (Eq, Generics.Generic, TH.Lift, DeepSeq.NFData, Show)
+    deriving (Eq, TH.Lift, Show)
+
+instance DeepSeq.NFData Pointer where
+    rnf = DeepSeq.rnf . toList
 
 fromList :: [Token.Token] -> Pointer
 fromList = Pointer

--- a/source/library/Argo/Internal/Pointer/Token.hs
+++ b/source/library/Argo/Internal/Pointer/Token.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DeriveLift #-}
 
 module Argo.Internal.Pointer.Token where
@@ -15,11 +13,13 @@ import qualified Argo.Vendor.Text as Text
 import qualified Argo.Vendor.Transformers as Trans
 import qualified Data.String as String
 import qualified Data.Word as Word
-import qualified GHC.Generics as Generics
 
 newtype Token
     = Token Text.Text
-    deriving (Eq, Generics.Generic, TH.Lift, DeepSeq.NFData, Show)
+    deriving (Eq, TH.Lift, Show)
+
+instance DeepSeq.NFData Token where
+    rnf = DeepSeq.rnf . toText
 
 instance String.IsString Token where
     fromString = fromText . String.fromString

--- a/source/library/Argo/Internal/Schema/Identifier.hs
+++ b/source/library/Argo/Internal/Schema/Identifier.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DeriveLift #-}
 
 module Argo.Internal.Schema.Identifier where
@@ -8,11 +6,13 @@ import qualified Argo.Vendor.DeepSeq as DeepSeq
 import qualified Argo.Vendor.TemplateHaskell as TH
 import qualified Argo.Vendor.Text as Text
 import qualified Data.String as String
-import qualified GHC.Generics as Generics
 
 newtype Identifier
     = Identifier Text.Text
-    deriving (Eq, Generics.Generic, TH.Lift, DeepSeq.NFData, Ord, Show)
+    deriving (Eq, TH.Lift, Ord, Show)
+
+instance DeepSeq.NFData Identifier where
+    rnf = DeepSeq.rnf . toText
 
 instance String.IsString Identifier where
     fromString = fromText . String.fromString

--- a/source/library/Argo/Internal/Schema/Schema.hs
+++ b/source/library/Argo/Internal/Schema/Schema.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DeriveLift #-}
 
 module Argo.Internal.Schema.Schema where
@@ -13,7 +11,6 @@ import qualified Argo.Vendor.DeepSeq as DeepSeq
 import qualified Argo.Vendor.TemplateHaskell as TH
 import qualified Argo.Vendor.Text as Text
 import qualified Data.List.NonEmpty as NonEmpty
-import qualified GHC.Generics as Generics
 import qualified Numeric.Natural as Natural
 
 -- | A JSON Schema.
@@ -35,7 +32,22 @@ data Schema
     | Ref Identifier.Identifier
     | String (Maybe Natural.Natural) (Maybe Natural.Natural)
     | True
-    deriving (Eq, Generics.Generic, TH.Lift, DeepSeq.NFData, Show)
+    deriving (Eq, TH.Lift, Show)
+
+instance DeepSeq.NFData Schema where
+    rnf x = case x of
+        Array a b c d -> DeepSeq.rnf (a, b, c, d)
+        Boolean -> ()
+        Const a -> DeepSeq.rnf a
+        Argo.Internal.Schema.Schema.False -> ()
+        Integer a b -> DeepSeq.rnf (a, b)
+        Null -> ()
+        Number -> ()
+        Object a b c -> DeepSeq.rnf (a, b, c)
+        OneOf a -> DeepSeq.rnf a
+        Ref a -> DeepSeq.rnf a
+        String a b -> DeepSeq.rnf (a, b)
+        Argo.Internal.Schema.Schema.True -> ()
 
 instance Semigroup Schema where
     x <> y = case (x, y) of

--- a/source/library/Argo/Internal/Type/Decimal.hs
+++ b/source/library/Argo/Internal/Type/Decimal.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DeriveLift #-}
 
 module Argo.Internal.Type.Decimal where
@@ -10,11 +8,13 @@ import qualified Argo.Vendor.DeepSeq as DeepSeq
 import qualified Argo.Vendor.TemplateHaskell as TH
 import qualified Data.List as List
 import qualified Data.Ratio as Ratio
-import qualified GHC.Generics as Generics
 import qualified Numeric
 
 data Decimal = Decimal Integer Integer
-    deriving (Eq, Generics.Generic, TH.Lift, DeepSeq.NFData, Show)
+    deriving (Eq, TH.Lift, Show)
+
+instance DeepSeq.NFData Decimal where
+    rnf (Decimal s e) = DeepSeq.rnf (s, e)
 
 negate :: Decimal -> Decimal
 negate (Decimal s e) = Decimal (-s) e

--- a/source/library/Argo/Internal/Type/Permission.hs
+++ b/source/library/Argo/Internal/Type/Permission.hs
@@ -1,17 +1,17 @@
-{-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DeriveLift #-}
 
 module Argo.Internal.Type.Permission where
 
 import qualified Argo.Vendor.DeepSeq as DeepSeq
 import qualified Argo.Vendor.TemplateHaskell as TH
-import qualified GHC.Generics as Generics
 
 data Permission
     = Allow
     | Forbid
-    deriving (Eq, Generics.Generic, TH.Lift, DeepSeq.NFData, Show)
+    deriving (Eq, TH.Lift, Show)
+
+instance DeepSeq.NFData Permission where
+    rnf = flip seq ()
 
 toBool :: Permission -> Bool
 toBool x = case x of


### PR DESCRIPTION
The goal of this PR is to define instances manually rather than using `DeriveGeneric`, `DeriveAnyClass`, and `DeriveLift`. 